### PR TITLE
Code review: timeout, validation, SSL bootstrap, tests, CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install package + dev deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Run tests
+        run: pytest mcp_server/tests/ -v

--- a/README.en.md
+++ b/README.en.md
@@ -270,6 +270,9 @@ Any MCP client that follows the [Model Context Protocol specification](https://m
 **Slow first query**
 → On startup the server lazy-starts Playwright in the background (~12s). First `search_judgments` keyword call may block briefly if warmup hasn't finished. Subsequent calls are fast.
 
+**Search returns "搜尋累計超時 ... 停止分頁" (cumulative search timeout)**
+→ The total search budget defaults to 120 seconds (`config.py:SEARCH_GLOBAL_TIMEOUT`). Broad keywords (e.g. "契約") can paginate through many results. Mitigations: narrow the `keyword`, add `court` / `year_from` / `year_to` filters, or lower `max_results`. Partial results still return.
+
 ---
 
 ## Data sources

--- a/README.md
+++ b/README.md
@@ -270,6 +270,9 @@ Claude Cowork 跑在 Claude Desktop 裡面，**共用同一個 `claude_desktop_c
 **第一次查詢很慢**
 → 啟動時伺服器會在背景延遲啟動 Playwright（~12 秒）。第一次 `search_judgments` 關鍵字查詢若 warmup 還沒完成可能會卡一下。後續查詢會很快。
 
+**搜尋回傳「搜尋累計超時 ... 停止分頁」**
+→ 預設整個搜尋累計上限是 120 秒（`config.py:SEARCH_GLOBAL_TIMEOUT`）。若關鍵字過廣（如「契約」）會掃過大量分頁。對策：縮小 `keyword`、加 `court`/`year_from`/`year_to` 過濾、或調低 `max_results`。仍會回傳已收到的部分結果。
+
 **`ssl.SSLCertVerificationError: ... Missing Subject Key Identifier`**
 → 這是 OpenSSL 3.6+ 對 TWCA Global Root CA 的廣泛 rejection，**不是 certifi 舊的問題**。TWCA Global Root CA 在 Mozilla bundle 裡的版本本體就缺 Subject Key Identifier 擴充，升 certifi 到最新也沒用。本 repo 透過 [`truststore`](https://github.com/sethmlarson/truststore) 套件讓 Python 改用作業系統原生的 trust store（macOS Security framework、Windows CryptoAPI、Linux 系統 CA），**所有路徑都保留完整 SSL 驗證（`verify=True`）**，不使用 `verify=False`。這在 macOS、Windows 以及 OpenSSL <3.6 的 Linux 都能正常工作。OpenSSL 3.6+ 的 Linux 環境（Fedora 40+、未來的 Ubuntu LTS）truststore 幫不上忙，但 `get_judgment` 有 Playwright fallback（用 Chromium 自己的 SSL stack）仍可運作；`query_regulation` 在那個環境會失敗，歡迎 issue 回報。
 

--- a/mcp_server/config.py
+++ b/mcp_server/config.py
@@ -46,6 +46,7 @@ CACHE_PCODE_TTL = 2592000      # 30 天
 # Playwright 設定
 PLAYWRIGHT_HEADLESS = True
 PLAYWRIGHT_TIMEOUT = 60000     # 60 秒（法院網站高負載時段可能較慢）
+SEARCH_GLOBAL_TIMEOUT = 120.0  # 秒；分頁累計上限，超過就回傳已收到的部分結果
 SEARCH_RATE_LIMIT = 5          # 每分鐘最多 5 次
 SEARCH_DELAY_MIN = 1.0         # 秒
 SEARCH_DELAY_MAX = 3.0         # 秒

--- a/mcp_server/config.py
+++ b/mcp_server/config.py
@@ -21,8 +21,8 @@
 # This preserves *full* SSL verification (verify=True) on macOS + Windows
 # and the majority of Linux installations. No `verify=False` is needed
 # anywhere in the codebase.
-import truststore
-truststore.inject_into_ssl()
+from mcp_server.ssl_setup import inject_os_trust_store
+inject_os_trust_store()
 
 from pathlib import Path
 

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -42,8 +42,8 @@ async def _maybe_update_pcode_all():
         await loop.run_in_executor(None, update_pcode_all)
         reload_pcode_all()
         logger.info("pcode_all.json 更新完成")
-    except Exception as e:
-        logger.warning("pcode_all.json 更新失敗: %s", e)
+    except Exception:
+        logger.exception("pcode_all.json 更新失敗（將沿用既有資料）")
 
 
 @asynccontextmanager

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -147,6 +147,9 @@ async def search_judgments(
     Returns:
         包含搜尋結果的字典：success, query, total_count, results, cached, timestamp
     """
+    if max_results <= 0:
+        return {"success": False, "error": "max_results 必須大於 0"}
+
     # 硬上限防止 OOM（100 頁 × 20 筆 = 2000 筆，但實務上 200 已足夠）
     max_results = min(max_results, 200)
     logger.info("search_judgments: keyword=%r, court=%r, case_type=%r, "
@@ -343,6 +346,8 @@ async def search_regulations(keyword: str, offset: int = 0, exclude_abolished: b
     """
     if not keyword:
         return {"success": False, "error": "請提供搜尋關鍵字"}
+    if offset < 0:
+        return {"success": False, "error": "offset 不可為負數"}
 
     logger.info("search_regulations: keyword=%r, offset=%d, exclude_abolished=%s",
                 keyword, offset, exclude_abolished)

--- a/mcp_server/ssl_setup.py
+++ b/mcp_server/ssl_setup.py
@@ -1,0 +1,17 @@
+"""Shared SSL trust-store bootstrap."""
+
+import truststore
+
+_INJECTED = False
+
+
+def inject_os_trust_store() -> None:
+    """Patch Python SSL once so http clients use the OS trust store."""
+    global _INJECTED
+    if _INJECTED:
+        return
+    truststore.inject_into_ssl()
+    _INJECTED = True
+
+
+inject_os_trust_store()

--- a/mcp_server/tests/test_judicial_doc.py
+++ b/mcp_server/tests/test_judicial_doc.py
@@ -1,0 +1,52 @@
+"""JudgmentDocClient 集成測試：白名單、快取、URL 驗證"""
+
+import pytest
+
+from mcp_server.cache.db import CacheDB
+from mcp_server.tools.judicial_doc import JudgmentDocClient
+
+
+@pytest.fixture
+async def cache(tmp_path):
+    db = CacheDB(db_path=tmp_path / "test_cache.db")
+    await db.initialize()
+    yield db
+    await db.close()
+
+
+@pytest.fixture
+async def client(cache):
+    c = JudgmentDocClient(cache)
+    yield c
+    await c.close()
+
+
+@pytest.mark.asyncio
+async def test_get_by_url_rejects_non_whitelisted_domain(client):
+    """SSRF 防護：非 ALLOWED_DOMAINS 必須被拒絕"""
+    result = await client.get_by_url("https://evil.example.com/id=x")
+    assert result["success"] is False
+    assert "域名" in result["error"] or "whitelist" in result["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_get_by_url_rejects_file_scheme(client):
+    """file:// 絕對不該放行"""
+    result = await client.get_by_url("file:///etc/passwd")
+    assert result["success"] is False
+
+
+@pytest.mark.asyncio
+async def test_get_by_jid_uses_cache(client, cache):
+    """已快取的 JID 應直接返回，不發 HTTP"""
+    jid = "TPSV,104,台上,472,20150326,1"
+    await cache.set_judgment(jid, {
+        "case_id": "104 台上 472",
+        "court": "最高法院",
+        "full_text": "測試用快取內容",
+    }, source="test")
+
+    result = await client.get_by_jid(jid)
+    assert result["success"] is True
+    assert result["cached"] is True
+    assert result["court"] == "最高法院"

--- a/mcp_server/tests/test_judicial_search.py
+++ b/mcp_server/tests/test_judicial_search.py
@@ -1,0 +1,101 @@
+"""JudicialSearchBrowser 集成測試
+
+用 in-memory SQLite cache + monkeypatch 繞過 Playwright，
+驗證輸入驗證、快取命中、例外處理與全局超時行為。
+"""
+
+import asyncio
+from pathlib import Path
+
+import httpx
+import pytest
+
+from mcp_server.cache.db import CacheDB
+from mcp_server.tools.judicial_search import JudicialSearchBrowser
+
+
+@pytest.fixture
+async def cache(tmp_path):
+    db = CacheDB(db_path=tmp_path / "test_cache.db")
+    await db.initialize()
+    yield db
+    await db.close()
+
+
+@pytest.fixture
+async def browser(cache):
+    yield JudicialSearchBrowser(cache)
+
+
+@pytest.mark.asyncio
+async def test_search_requires_any_key(browser):
+    """完全沒給任何查詢條件 → 回傳明確驗證訊息"""
+    result = await browser.search()
+    assert result["success"] is False
+    assert "keyword" in result["error"] or "case_number" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_search_returns_cached_result(browser, cache):
+    """快取命中時應直接回傳，不觸發 Playwright"""
+    params = {
+        "keyword": "借名登記",
+        "court": "",
+        "case_type": "",
+        "year_from": 0,
+        "year_to": 0,
+        "case_word": "",
+        "case_number": "",
+        "main_text": "",
+    }
+    await cache.set_search(params, {"success": True, "results": [{"jid": "X,1,2,3"}], "total_count": 1})
+
+    result = await browser.search(keyword="借名登記")
+    assert result["success"] is True
+    assert result["cached"] is True
+    assert result["total_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_search_generic_exception_no_leak(browser, monkeypatch):
+    """任意例外應被捕捉並回傳通用訊息，不外洩 str(e) 內部細節"""
+    async def boom(self):
+        raise RuntimeError("INTERNAL /Users/secret/path leak")
+    monkeypatch.setattr(JudicialSearchBrowser, "_ensure_browser", boom)
+
+    result = await browser.search(keyword="契約")
+    assert result["success"] is False
+    assert "/Users/secret/path" not in result["error"]
+    assert "RuntimeError" not in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_search_httpx_exception_gives_friendly_message(browser, monkeypatch):
+    """httpx.HTTPError → 連線類訊息，仍不洩 raw"""
+    async def boom(self):
+        raise httpx.ConnectError("[Errno -2] Temporary failure /Users/secret")
+    monkeypatch.setattr(JudicialSearchBrowser, "_ensure_browser", boom)
+
+    result = await browser.search(keyword="契約")
+    assert result["success"] is False
+    assert "/Users/secret" not in result["error"]
+    assert "連線" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_search_timeout_exception_gives_friendly_message(browser, monkeypatch):
+    """asyncio.TimeoutError → 逾時訊息分流"""
+    async def boom(self):
+        raise asyncio.TimeoutError()
+    monkeypatch.setattr(JudicialSearchBrowser, "_ensure_browser", boom)
+
+    result = await browser.search(keyword="契約")
+    assert result["success"] is False
+    assert "逾時" in result["error"]
+
+
+def test_global_timeout_constant_exists_and_reasonable():
+    """SEARCH_GLOBAL_TIMEOUT 須存在且落在合理區間"""
+    from mcp_server.config import SEARCH_GLOBAL_TIMEOUT
+    assert isinstance(SEARCH_GLOBAL_TIMEOUT, (int, float))
+    assert 30 <= SEARCH_GLOBAL_TIMEOUT <= 600

--- a/mcp_server/tests/test_judicial_search.py
+++ b/mcp_server/tests/test_judicial_search.py
@@ -5,7 +5,6 @@
 """
 
 import asyncio
-from pathlib import Path
 
 import httpx
 import pytest
@@ -92,6 +91,57 @@ async def test_search_timeout_exception_gives_friendly_message(browser, monkeypa
     result = await browser.search(keyword="契約")
     assert result["success"] is False
     assert "逾時" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_precise_case_with_main_text_skips_http_fast_path(browser, monkeypatch):
+    """主文過濾存在時，不可走會忽略條件的精確案號 fast path"""
+    calls: list[str] = []
+
+    async def no_wait():
+        return None
+
+    class DummyPage:
+        async def close(self):
+            return None
+
+    class DummyContext:
+        async def new_page(self):
+            return DummyPage()
+
+        async def close(self):
+            return None
+
+    class DummyBrowser:
+        async def new_context(self, **kwargs):
+            return DummyContext()
+
+    async def ensure_browser(self):
+        self._browser = DummyBrowser()
+
+    async def precise_search(self, params, max_results):
+        calls.append("precise")
+        return [{"jid": "HTTP,1,2,3", "case_id": "http"}]
+
+    async def perform_search(self, page, params, max_results):
+        calls.append("perform")
+        assert params["main_text"] == "原告之訴駁回"
+        return [{"jid": "PW,1,2,3", "case_id": "playwright", "court_level": 1}]
+
+    monkeypatch.setattr(browser, "_rate_limit", no_wait)
+    monkeypatch.setattr(JudicialSearchBrowser, "_ensure_browser", ensure_browser)
+    monkeypatch.setattr(JudicialSearchBrowser, "_precise_search_http", precise_search)
+    monkeypatch.setattr(JudicialSearchBrowser, "_perform_search", perform_search)
+
+    result = await browser.search(
+        case_word="台上",
+        case_number="123",
+        main_text="原告之訴駁回",
+    )
+
+    assert result["success"] is True
+    assert [r["jid"] for r in result["results"]] == ["PW,1,2,3"]
+    assert calls == ["perform"]
 
 
 def test_global_timeout_constant_exists_and_reasonable():

--- a/mcp_server/tests/test_regulation_client.py
+++ b/mcp_server/tests/test_regulation_client.py
@@ -1,0 +1,63 @@
+"""RegulationClient 集成測試：pcode 解析（精確 / 縮寫 / 模糊）+ URL 驗證"""
+
+import pytest
+
+from mcp_server.cache.db import CacheDB
+from mcp_server.tools.regulations import RegulationClient
+from mcp_server.config import validate_url_domain
+
+
+@pytest.fixture
+async def cache(tmp_path):
+    db = CacheDB(db_path=tmp_path / "test_cache.db")
+    await db.initialize()
+    yield db
+    await db.close()
+
+
+@pytest.fixture
+async def client(cache):
+    c = RegulationClient(cache)
+    yield c
+    await c.close()
+
+
+class TestResolvePcode:
+    def test_exact_match(self, client):
+        assert client.resolve_pcode("民法") == "B0000001"
+
+    def test_alias_expansion_laobi(self, client):
+        """勞基法 → 勞動基準法"""
+        assert client.resolve_pcode("勞基法") == client.resolve_pcode("勞動基準法")
+
+    def test_alias_expansion_xiaobao(self, client):
+        """消保法 → 消費者保護法"""
+        assert client.resolve_pcode("消保法") == client.resolve_pcode("消費者保護法")
+
+    def test_unknown_returns_none(self, client):
+        assert client.resolve_pcode("完全不存在的法規名稱_xyz_2099") is None
+
+    def test_short_name_prefers_exact(self, client):
+        """查「保險法」應命中「保險法」而非「全民健康保險法」"""
+        pcode = client.resolve_pcode("保險法")
+        assert pcode == "G0390002"
+
+
+class TestUrlWhitelist:
+    @pytest.mark.parametrize("url", [
+        "https://judgment.judicial.gov.tw/FJUD/data.aspx?id=x",
+        "https://data.judicial.gov.tw/anything",
+        "https://law.moj.gov.tw/LawClass/LawSingle.aspx?pcode=B0000001",
+    ])
+    def test_allowed(self, url):
+        assert validate_url_domain(url) is True
+
+    @pytest.mark.parametrize("url", [
+        "https://evil.example.com/",
+        "http://169.254.169.254/latest/meta-data/",
+        "https://judgment.judicial.gov.tw.evil.com/",
+        "file:///etc/passwd",
+        "https://judicial.gov.tw/",  # 缺 judgment/data prefix
+    ])
+    def test_blocked(self, url):
+        assert validate_url_domain(url) is False

--- a/mcp_server/tests/test_server.py
+++ b/mcp_server/tests/test_server.py
@@ -1,0 +1,32 @@
+"""server.py tool-level validation tests."""
+
+import asyncio
+import importlib
+import sys
+
+import pytest
+
+import mcp_server.server as server
+
+
+@pytest.mark.asyncio
+async def test_search_judgments_rejects_non_positive_max_results():
+    result = await server.search_judgments(keyword="契約", max_results=0)
+    assert result["success"] is False
+    assert "max_results" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_search_regulations_rejects_negative_offset():
+    result = await server.search_regulations("法", offset=-1)
+    assert result["success"] is False
+    assert "offset" in result["error"]
+
+
+def test_updater_import_bootstraps_ssl_setup():
+    sys.modules.pop("mcp_server.updater", None)
+    sys.modules.pop("mcp_server.ssl_setup", None)
+
+    importlib.import_module("mcp_server.updater")
+
+    assert "mcp_server.ssl_setup" in sys.modules

--- a/mcp_server/tools/judicial_doc.py
+++ b/mcp_server/tools/judicial_doc.py
@@ -211,6 +211,6 @@ class JudgmentDocClient:
                 await page.close()
                 await context.close()
 
-        except Exception as e:
-            logger.error("Playwright 取得裁判書失敗: %s", e)
+        except Exception:
+            logger.exception("Playwright 取得裁判書失敗")
             return None

--- a/mcp_server/tools/judicial_search.py
+++ b/mcp_server/tools/judicial_search.py
@@ -121,7 +121,14 @@ class JudicialSearchBrowser:
             }
 
         # ── 精確案號搜尋：case_word + case_number → HTTP GET（快、準） ──
-        if params.get("case_word") and params.get("case_number"):
+        # 只有在沒有全文/主文過濾條件時才可安全走 fast path；
+        # 否則會忽略 keyword / main_text 並把錯結果寫進快取。
+        if (
+            params.get("case_word")
+            and params.get("case_number")
+            and not params.get("keyword")
+            and not params.get("main_text")
+        ):
             http_results = await self._precise_search_http(params, max_results)
             if http_results is not None:
                 data = {

--- a/mcp_server/tools/judicial_search.py
+++ b/mcp_server/tools/judicial_search.py
@@ -14,6 +14,7 @@ from mcp_server.config import (
     PLAYWRIGHT_TIMEOUT,
     SEARCH_DELAY_MIN,
     SEARCH_DELAY_MAX,
+    SEARCH_GLOBAL_TIMEOUT,
     COURT_CODES,
     CASE_TYPE_CODES,
     validate_url_domain,
@@ -167,11 +168,28 @@ class JudicialSearchBrowser:
 
             return data
 
-        except Exception as e:
-            logger.error("搜尋失敗: %s", e)
+        except asyncio.TimeoutError:
+            logger.exception("搜尋逾時")
             return {
                 "success": False,
-                "error": str(e),
+                "error": "搜尋逾時，請稍後重試或縮小查詢範圍",
+                "query": params,
+                "timestamp": datetime.now().isoformat(),
+            }
+        except httpx.HTTPError:
+            logger.exception("搜尋連線錯誤")
+            return {
+                "success": False,
+                "error": "連線司法院系統失敗，請稍後重試",
+                "query": params,
+                "timestamp": datetime.now().isoformat(),
+            }
+        except Exception:
+            # 完整 traceback 進 log；對外只回通用訊息，避免內部細節（路徑、依賴版本）外洩
+            logger.exception("搜尋發生未預期錯誤")
+            return {
+                "success": False,
+                "error": "搜尋發生未預期錯誤，請查看 server log 取得詳細資訊",
                 "query": params,
                 "timestamp": datetime.now().isoformat(),
             }
@@ -399,6 +417,9 @@ class JudicialSearchBrowser:
         seen_jids: set[str] = set()
         page_num = 1
         MAX_PAGES = 100  # 每頁 20 筆 × 100 頁 = 2000 筆上限
+        # 全局超時：避免單次搜尋耗時超過 client (e.g. Claude) 容忍上限
+        loop = asyncio.get_running_loop()
+        search_start = loop.time()
 
         # 先找 iframe（搜尋結果在 iframe-data 中）
         iframe = page.frame(name="iframe-data")
@@ -408,6 +429,13 @@ class JudicialSearchBrowser:
             logger.warning("iframe-data 不存在，降級到主頁解析（分頁可能不可用）")
 
         while len(all_results) < max_results and page_num <= MAX_PAGES:
+            elapsed = loop.time() - search_start
+            if elapsed > SEARCH_GLOBAL_TIMEOUT:
+                logger.warning(
+                    "搜尋累計超時 %.1fs > %.1fs，停止分頁，回傳已收到 %d 筆",
+                    elapsed, SEARCH_GLOBAL_TIMEOUT, len(all_results),
+                )
+                break
             # 取得當前頁面內容
             target = iframe if iframe is not None else page
             try:

--- a/mcp_server/updater.py
+++ b/mcp_server/updater.py
@@ -1,7 +1,7 @@
 """從全國法規資料庫官方 API 更新 pcode_all.json（v2 含廢止標記）
 
 用法：
-    .venv/bin/python scripts/update_pcode_all.py
+    .venv/bin/python -m mcp_server.updater
 
 官方 API：
     - 法律：https://law.moj.gov.tw/api/Ch/Law/JSON（ZIP → ChLaw.json）
@@ -21,6 +21,10 @@ from datetime import datetime, time as dt_time, timedelta
 from pathlib import Path
 from urllib.parse import parse_qs, urlparse
 from zoneinfo import ZoneInfo
+
+from mcp_server.ssl_setup import inject_os_trust_store
+
+inject_os_trust_store()
 
 import httpx
 
@@ -99,11 +103,11 @@ def update_pcode_all(output_path: Path | None = None) -> dict:
     law_count = 0
     order_count = 0
 
-    # SSL verification via OS-native trust store (truststore injected at
-    # config.py import time). pcode_all.json is written to disk and
+    # SSL verification via OS-native trust store. pcode_all.json is written
+    # to disk and
     # trusted by the next startup, so strict verification matters here;
     # with truststore we now get full verification on macOS / Windows /
-    # OpenSSL <3.6 Linux. On OpenSSL 3.6+ Linux this update will fail
+    # OpenSSL <3.6 Linux. On OpenSSL 3.6+ Linux this update will still fail
     # but the server still starts on the existing pcode_all.json shipped
     # in the repo.
     with httpx.Client(follow_redirects=True, verify=True) as client:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,3 +58,7 @@ include = ["mcp_server*"]
 
 [tool.setuptools.package-data]
 mcp_server = ["data/*.json"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["mcp_server/tests"]


### PR DESCRIPTION
## Summary

從頭對這個 repo 做了一輪 code review，挑出幾個明顯可以補強的地方並附上修復。測試皆已在本地跑過：**63 passed**（原 37 + 新 26）。

分成 5 個小而獨立的 commit，方便逐一 review 或挑選合併：

### 1. `c979b48` — 加 Playwright 全局超時並強化例外處理
- `config.py` 新增 `SEARCH_GLOBAL_TIMEOUT=120s`。`judicial_search._perform_search` 分頁迴圈每輪檢查累計時間，超過就 break 並回傳已收到的部分結果。
  - 動機：`MAX_PAGES=100` 只限了「頁數」，沒限「時間」。若每頁平均 30 秒就能卡到 50 分鐘，MCP client（如 Claude Desktop）通常 5 分鐘就斷了。
- `judicial_search` / `judicial_doc` / `server` 改用 `logger.exception()`，記錄完整 traceback；對外回傳通用訊息（避免把 `str(e)` 連內部路徑直接丟給 LLM 轉述）。
- `judicial_search.search()` 例外分流 `asyncio.TimeoutError` / `httpx.HTTPError` / generic，給出對應的人類可讀訊息。

### 2. `9776ea0` — docs: README 補累計超時的故障排除條目
中英雙語，提示縮小 `keyword`、加 `court` / `year_*` 過濾或降低 `max_results`。

### 3. `43d856a` — test: 補核心邏輯的集成測試
用 `pytest-asyncio` auto mode + tmp SQLite，不需要網路或 Playwright 就能跑：
- **judicial_search**：輸入驗證、快取命中短路、三類例外訊息不洩露 `str(e)`、`SEARCH_GLOBAL_TIMEOUT` 存在且合理。
- **judicial_doc**：`ALLOWED_DOMAINS` 白名單對 `evil.example.com` / `file://` / `judgment.judicial.gov.tw.evil.com` 子域冒充 / 裸 `judicial.gov.tw` 都回 `False`；JID 快取命中短路 HTTP。
- **regulation**：`resolve_pcode` 精確 / 縮寫展開（勞基法、消保法）/ 短名稱優先精確匹配（保險法 ≠ 全民健康保險法）/ 未知回 `None`。
- `pyproject.toml` 加 `[tool.pytest.ini_options] asyncio_mode = "auto"`、`testpaths`。

### 4. `6a4b354` — ci: GitHub Actions pytest workflow
Python 3.10 / 3.11 / 3.12 矩陣。`fail-fast: false` 以便看全部版本結果。

### 5. `17471d1` — fix review findings around search filters and ssl bootstrap
- 精確案號 HTTP fast path 現在只在沒有 `keyword` / `main_text` 時啟用，避免靜默忽略過濾條件，並避免把錯誤結果寫進快取。
- 新增共用 `mcp_server/ssl_setup.py`，讓 `config.py` 與獨立執行的 `mcp_server.updater` 都會在建立 `httpx` client 前注入 truststore。
- 在 tool layer 驗證 `search_judgments(max_results > 0)` 與 `search_regulations(offset >= 0)`，避免 Python slice semantics 回傳尾段資料或其他怪異結果。
- 補回歸測試覆蓋以上三個 review findings。

## Test plan

- [x] 本地 `.venv/bin/python -m pytest -q` → 63 passed
- [ ] CI 首次執行（本 PR branch push 後會觸發）
- [ ] 手動驗證 `search_judgments(keyword="契約")`（很廣的關鍵字）現在會在 120s 內回傳 partial results 而不是卡住

## 其他 review 發現但未納入本 PR

為了讓這個 PR 聚焦、可審可合併，以下只列不改：

- `_perform_search`（`judicial_search.py`）仍偏長，可拆成 `_goto_search_form / _fill_form / _submit / _collect_pages`
- `regulations.py` 內 `except httpx.HTTPError` 三處重複，可抽共用裝飾器
- Pydantic models 已定義但工具函式回傳 raw dict，驗證能力未發揮
- `CASE_TYPE_CODES` 的 `V/M/A/P` 建議加來源註解

若有興趣，這些可以分別另開 issue / PR 處理。

---

Code review 與修改在 Claude Code 協助下完成。歡迎指正任何判斷錯誤的地方。
