### PR TITLE
Rework PR #2 against current main (SSL / validation / fast-path / exception dispatch)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install package + dev deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Run tests
+        run: pytest mcp_server/tests/ -v

--- a/mcp_server/config.py
+++ b/mcp_server/config.py
@@ -19,8 +19,8 @@
 # This preserves *full* SSL verification (verify=True) on macOS + Windows
 # and the majority of Linux installations. No `verify=False` is needed
 # anywhere in the codebase.
-import truststore
-truststore.inject_into_ssl()
+from mcp_server.ssl_setup import inject_os_trust_store
+inject_os_trust_store()
 
 from pathlib import Path
 

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -145,6 +145,9 @@ async def search_judgments(
     Returns:
         包含搜尋結果的字典：success, query, total_count, results, cached, timestamp
     """
+    if max_results <= 0:
+        return {"success": False, "error": "max_results 必須大於 0"}
+
     # 硬上限防止 OOM（100 頁 × 20 筆 = 2000 筆，但實務上 200 已足夠）
     max_results = min(max_results, 200)
     logger.info("search_judgments: keyword=%r, court=%r, case_type=%r, "
@@ -341,6 +344,8 @@ async def search_regulations(keyword: str, offset: int = 0, exclude_abolished: b
     """
     if not keyword:
         return {"success": False, "error": "請提供搜尋關鍵字"}
+    if offset < 0:
+        return {"success": False, "error": "offset 不可為負數"}
 
     logger.info("search_regulations: keyword=%r, offset=%d, exclude_abolished=%s",
                 keyword, offset, exclude_abolished)

--- a/mcp_server/ssl_setup.py
+++ b/mcp_server/ssl_setup.py
@@ -1,0 +1,14 @@
+"""Shared SSL trust-store bootstrap."""
+
+import truststore
+
+_INJECTED = False
+
+
+def inject_os_trust_store() -> None:
+    """Patch Python SSL once so http clients use the OS trust store."""
+    global _INJECTED
+    if _INJECTED:
+        return
+    truststore.inject_into_ssl()
+    _INJECTED = True

--- a/mcp_server/tests/test_judicial_doc.py
+++ b/mcp_server/tests/test_judicial_doc.py
@@ -1,0 +1,53 @@
+"""JudgmentDocClient 集成測試：白名單、快取、URL 驗證"""
+
+import pytest
+
+from mcp_server.cache.db import CacheDB
+from mcp_server.tools.judicial_doc import JudgmentDocClient
+from mcp_server.tools.waf_bypass import JudicialWAFBypass
+
+
+@pytest.fixture
+async def cache(tmp_path):
+    db = CacheDB(db_path=tmp_path / "test_cache.db")
+    await db.initialize()
+    yield db
+    await db.close()
+
+
+@pytest.fixture
+async def client(cache):
+    c = JudgmentDocClient(cache, JudicialWAFBypass())
+    yield c
+    await c.close()
+
+
+@pytest.mark.asyncio
+async def test_get_by_url_rejects_non_whitelisted_domain(client):
+    """SSRF 防護：非 ALLOWED_DOMAINS 必須被拒絕"""
+    result = await client.get_by_url("https://evil.example.com/id=x")
+    assert result["success"] is False
+    assert "域名" in result["error"] or "whitelist" in result["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_get_by_url_rejects_file_scheme(client):
+    """file:// 絕對不該放行"""
+    result = await client.get_by_url("file:///etc/passwd")
+    assert result["success"] is False
+
+
+@pytest.mark.asyncio
+async def test_get_by_jid_uses_cache(client, cache):
+    """已快取的 JID 應直接返回，不發 HTTP"""
+    jid = "TPSV,104,台上,472,20150326,1"
+    await cache.set_judgment(jid, {
+        "case_id": "104 台上 472",
+        "court": "最高法院",
+        "full_text": "測試用快取內容",
+    }, source="test")
+
+    result = await client.get_by_jid(jid)
+    assert result["success"] is True
+    assert result["cached"] is True
+    assert result["court"] == "最高法院"

--- a/mcp_server/tests/test_judicial_search.py
+++ b/mcp_server/tests/test_judicial_search.py
@@ -90,7 +90,7 @@ async def test_search_httpx_exception_gives_friendly_message(client, monkeypatch
 
 @pytest.mark.asyncio
 async def test_search_timeout_exception_gives_friendly_message(client, monkeypatch):
-    """asyncio.TimeoutError → 逾時訊息分流"""
+    """asyncio.TimeoutError → 逾時訊息分流（涵蓋 waf_bypass 收斂的 Playwright 逾時）"""
     async def boom(self, params, max_results):
         raise asyncio.TimeoutError()
     monkeypatch.setattr(JudicialSearchClient, "_keyword_search_http", boom)
@@ -99,6 +99,20 @@ async def test_search_timeout_exception_gives_friendly_message(client, monkeypat
     result = await client.search(keyword="契約")
     assert result["success"] is False
     assert "逾時" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_search_httpx_timeout_routes_to_timeout_arm(client, monkeypatch):
+    """httpx.TimeoutException 是 HTTPError 子類，必須先被 timeout arm 捕捉"""
+    async def boom(self, params, max_results):
+        raise httpx.ReadTimeout("timed out")
+    monkeypatch.setattr(JudicialSearchClient, "_keyword_search_http", boom)
+    monkeypatch.setattr(JudicialSearchClient, "_rate_limit", _no_rate_limit)
+
+    result = await client.search(keyword="契約")
+    assert result["success"] is False
+    assert "逾時" in result["error"]
+    assert "連線" not in result["error"]
 
 
 @pytest.mark.asyncio

--- a/mcp_server/tests/test_judicial_search.py
+++ b/mcp_server/tests/test_judicial_search.py
@@ -1,0 +1,130 @@
+"""JudicialSearchClient 集成測試
+
+用 in-memory SQLite cache + monkeypatch 繞過 HTTP，
+驗證輸入驗證、快取命中、例外處理與 fast-path 守衛。
+"""
+
+import asyncio
+
+import httpx
+import pytest
+
+from mcp_server.cache.db import CacheDB
+from mcp_server.tools.judicial_search import JudicialSearchClient
+from mcp_server.tools.waf_bypass import JudicialWAFBypass
+
+
+@pytest.fixture
+async def cache(tmp_path):
+    db = CacheDB(db_path=tmp_path / "test_cache.db")
+    await db.initialize()
+    yield db
+    await db.close()
+
+
+@pytest.fixture
+async def client(cache):
+    yield JudicialSearchClient(cache, JudicialWAFBypass())
+
+
+async def _no_rate_limit(self):
+    return None
+
+
+@pytest.mark.asyncio
+async def test_search_requires_any_key(client):
+    """完全沒給任何查詢條件 → 回傳明確驗證訊息"""
+    result = await client.search()
+    assert result["success"] is False
+    assert "keyword" in result["error"] or "case_number" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_search_returns_cached_result(client, cache):
+    """快取命中時應直接回傳，不觸發 HTTP"""
+    params = {
+        "keyword": "借名登記",
+        "court": "",
+        "case_type": "",
+        "year_from": 0,
+        "year_to": 0,
+        "case_word": "",
+        "case_number": "",
+        "main_text": "",
+    }
+    await cache.set_search(params, {"success": True, "results": [{"jid": "X,1,2,3"}], "total_count": 1})
+
+    result = await client.search(keyword="借名登記")
+    assert result["success"] is True
+    assert result["cached"] is True
+    assert result["total_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_search_generic_exception_no_leak(client, monkeypatch):
+    """任意例外應被捕捉並回傳通用訊息，不外洩 str(e) 內部細節"""
+    async def boom(self, params, max_results):
+        raise RuntimeError("INTERNAL /Users/secret/path leak")
+    monkeypatch.setattr(JudicialSearchClient, "_keyword_search_http", boom)
+    monkeypatch.setattr(JudicialSearchClient, "_rate_limit", _no_rate_limit)
+
+    result = await client.search(keyword="契約")
+    assert result["success"] is False
+    assert "/Users/secret/path" not in result["error"]
+    assert "RuntimeError" not in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_search_httpx_exception_gives_friendly_message(client, monkeypatch):
+    """httpx.HTTPError → 連線類訊息，仍不洩 raw"""
+    async def boom(self, params, max_results):
+        raise httpx.ConnectError("[Errno -2] Temporary failure /Users/secret")
+    monkeypatch.setattr(JudicialSearchClient, "_keyword_search_http", boom)
+    monkeypatch.setattr(JudicialSearchClient, "_rate_limit", _no_rate_limit)
+
+    result = await client.search(keyword="契約")
+    assert result["success"] is False
+    assert "/Users/secret" not in result["error"]
+    assert "連線" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_search_timeout_exception_gives_friendly_message(client, monkeypatch):
+    """asyncio.TimeoutError → 逾時訊息分流"""
+    async def boom(self, params, max_results):
+        raise asyncio.TimeoutError()
+    monkeypatch.setattr(JudicialSearchClient, "_keyword_search_http", boom)
+    monkeypatch.setattr(JudicialSearchClient, "_rate_limit", _no_rate_limit)
+
+    result = await client.search(keyword="契約")
+    assert result["success"] is False
+    assert "逾時" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_precise_case_with_main_text_skips_http_fast_path(client, monkeypatch):
+    """主文過濾存在時，不可走會忽略條件的精確案號 fast path"""
+    calls: list[str] = []
+
+    async def precise_search(self, params, max_results):
+        calls.append("precise")
+        return [{"jid": "HTTP,1,2,3", "case_id": "http"}]
+
+    async def keyword_search(self, params, max_results):
+        calls.append("keyword")
+        assert params["main_text"] == "原告之訴駁回"
+        return [{"jid": "KW,1,2,3", "case_id": "keyword"}]
+
+    monkeypatch.setattr(JudicialSearchClient, "_precise_search_http", precise_search)
+    monkeypatch.setattr(JudicialSearchClient, "_keyword_search_http", keyword_search)
+    monkeypatch.setattr(JudicialSearchClient, "_rate_limit", _no_rate_limit)
+
+    result = await client.search(
+        case_word="台上",
+        case_number="123",
+        main_text="原告之訴駁回",
+    )
+
+    assert result["success"] is True
+    assert [r["jid"] for r in result["results"]] == ["KW,1,2,3"]
+    assert calls == ["keyword"]

--- a/mcp_server/tests/test_regulation_client.py
+++ b/mcp_server/tests/test_regulation_client.py
@@ -1,0 +1,63 @@
+"""RegulationClient 集成測試：pcode 解析（精確 / 縮寫 / 模糊）+ URL 驗證"""
+
+import pytest
+
+from mcp_server.cache.db import CacheDB
+from mcp_server.tools.regulations import RegulationClient
+from mcp_server.config import validate_url_domain
+
+
+@pytest.fixture
+async def cache(tmp_path):
+    db = CacheDB(db_path=tmp_path / "test_cache.db")
+    await db.initialize()
+    yield db
+    await db.close()
+
+
+@pytest.fixture
+async def client(cache):
+    c = RegulationClient(cache)
+    yield c
+    await c.close()
+
+
+class TestResolvePcode:
+    def test_exact_match(self, client):
+        assert client.resolve_pcode("民法") == "B0000001"
+
+    def test_alias_expansion_laobi(self, client):
+        """勞基法 → 勞動基準法"""
+        assert client.resolve_pcode("勞基法") == client.resolve_pcode("勞動基準法")
+
+    def test_alias_expansion_xiaobao(self, client):
+        """消保法 → 消費者保護法"""
+        assert client.resolve_pcode("消保法") == client.resolve_pcode("消費者保護法")
+
+    def test_unknown_returns_none(self, client):
+        assert client.resolve_pcode("完全不存在的法規名稱_xyz_2099") is None
+
+    def test_short_name_prefers_exact(self, client):
+        """查「保險法」應命中「保險法」而非「全民健康保險法」"""
+        pcode = client.resolve_pcode("保險法")
+        assert pcode == "G0390002"
+
+
+class TestUrlWhitelist:
+    @pytest.mark.parametrize("url", [
+        "https://judgment.judicial.gov.tw/FJUD/data.aspx?id=x",
+        "https://data.judicial.gov.tw/anything",
+        "https://law.moj.gov.tw/LawClass/LawSingle.aspx?pcode=B0000001",
+    ])
+    def test_allowed(self, url):
+        assert validate_url_domain(url) is True
+
+    @pytest.mark.parametrize("url", [
+        "https://evil.example.com/",
+        "http://169.254.169.254/latest/meta-data/",
+        "https://judgment.judicial.gov.tw.evil.com/",
+        "file:///etc/passwd",
+        "https://judicial.gov.tw/",  # 缺 judgment/data prefix
+    ])
+    def test_blocked(self, url):
+        assert validate_url_domain(url) is False

--- a/mcp_server/tests/test_server.py
+++ b/mcp_server/tests/test_server.py
@@ -1,0 +1,34 @@
+"""server.py tool-level validation tests."""
+
+import importlib
+import sys
+
+import pytest
+
+import mcp_server.server as server
+
+
+@pytest.mark.asyncio
+async def test_search_judgments_rejects_non_positive_max_results():
+    result = await server.search_judgments(keyword="契約", max_results=0)
+    assert result["success"] is False
+    assert "max_results" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_search_regulations_rejects_negative_offset():
+    result = await server.search_regulations("法", offset=-1)
+    assert result["success"] is False
+    assert "offset" in result["error"]
+
+
+def test_updater_import_bootstraps_ssl_setup():
+    """驗證 updater 獨立 import 時會觸發 inject_os_trust_store（非只檢查 module 存在）"""
+    import mcp_server.ssl_setup as ssl_setup
+
+    ssl_setup._INJECTED = False
+    sys.modules.pop("mcp_server.updater", None)
+
+    importlib.import_module("mcp_server.updater")
+
+    assert ssl_setup._INJECTED is True

--- a/mcp_server/tools/judicial_search.py
+++ b/mcp_server/tools/judicial_search.py
@@ -100,7 +100,14 @@ class JudicialSearchClient:
             }
 
         # ── 精確案號搜尋：case_word + case_number → HTTP GET（快、準） ──
-        if params.get("case_word") and params.get("case_number"):
+        # 只有在沒有全文/主文過濾條件時才可安全走 fast path；
+        # 否則會忽略 keyword / main_text 並把錯結果寫進快取。
+        if (
+            params.get("case_word")
+            and params.get("case_number")
+            and not params.get("keyword")
+            and not params.get("main_text")
+        ):
             http_results = await self._precise_search_http(params, max_results)
             if http_results is not None:
                 data = {
@@ -134,11 +141,30 @@ class JudicialSearchClient:
 
             return data
 
-        except Exception as e:
-            logger.error("搜尋失敗: %s", e)
+        except (asyncio.TimeoutError, httpx.TimeoutException):
+            # httpx 的 timeout 實際型別是 httpx.TimeoutException（HTTPError 子類），
+            # 必須在 httpx.HTTPError arm 之前攔截。asyncio.TimeoutError 涵蓋
+            # waf_bypass 收斂上來的 Playwright warmup 逾時。
+            logger.exception("搜尋逾時")
             return {
                 "success": False,
-                "error": str(e),
+                "error": "搜尋逾時，請稍後重試或縮小查詢範圍",
+                "query": params,
+                "timestamp": datetime.now().isoformat(),
+            }
+        except httpx.HTTPError:
+            logger.exception("搜尋連線失敗")
+            return {
+                "success": False,
+                "error": "連線司法院網站失敗，請稍後重試",
+                "query": params,
+                "timestamp": datetime.now().isoformat(),
+            }
+        except Exception:
+            logger.exception("搜尋發生未預期錯誤")
+            return {
+                "success": False,
+                "error": "搜尋發生未預期錯誤，請查看 server log 取得詳細資訊",
                 "query": params,
                 "timestamp": datetime.now().isoformat(),
             }

--- a/mcp_server/tools/waf_bypass.py
+++ b/mcp_server/tools/waf_bypass.py
@@ -85,7 +85,10 @@ class JudicialWAFBypass:
 
     async def _run_warmup(self) -> None:
         try:
-            from playwright.async_api import async_playwright
+            from playwright.async_api import (
+                TimeoutError as PlaywrightTimeoutError,
+                async_playwright,
+            )
         except ImportError:
             raise RuntimeError(
                 "Playwright 為繞過司法院 F5 WAF 所必需。"
@@ -94,41 +97,46 @@ class JudicialWAFBypass:
 
         logger.info("WAF bypass: running Playwright warmup...")
         t0 = time.time()
-        async with async_playwright() as p:
-            browser = await p.chromium.launch(
-                headless=True,
-                args=["--no-sandbox", "--disable-gpu", "--disable-dev-shm-usage"],
-            )
-            try:
-                ctx = await browser.new_context(
-                    locale="zh-TW",
-                    timezone_id="Asia/Taipei",
-                    user_agent=(
-                        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
-                        "AppleWebKit/537.36 (KHTML, like Gecko) "
-                        "Chrome/120.0.0.0 Safari/537.36"
-                    ),
+        try:
+            async with async_playwright() as p:
+                browser = await p.chromium.launch(
+                    headless=True,
+                    args=["--no-sandbox", "--disable-gpu", "--disable-dev-shm-usage"],
                 )
-                page = await ctx.new_page()
-                await page.goto(
-                    _WARMUP_URL, wait_until="domcontentloaded", timeout=60000
-                )
-                # 等真表單出現（代表 F5 挑戰已過）
                 try:
-                    await page.wait_for_selector("#btnQry", state="visible", timeout=15000)
-                except Exception:
-                    logger.warning("WAF bypass: #btnQry 未顯示，cookies 可能仍無效")
-                cookies = await ctx.cookies()
-                self._cookies = {c["name"]: c["value"] for c in cookies}
-                self._last_warmup_at = time.time()
-                self._save_to_disk()
-                elapsed = time.time() - t0
-                logger.info(
-                    "WAF bypass: warmup OK in %.1fs, got %d cookies",
-                    elapsed, len(self._cookies),
-                )
-            finally:
-                await browser.close()
+                    ctx = await browser.new_context(
+                        locale="zh-TW",
+                        timezone_id="Asia/Taipei",
+                        user_agent=(
+                            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                            "AppleWebKit/537.36 (KHTML, like Gecko) "
+                            "Chrome/120.0.0.0 Safari/537.36"
+                        ),
+                    )
+                    page = await ctx.new_page()
+                    await page.goto(
+                        _WARMUP_URL, wait_until="domcontentloaded", timeout=60000
+                    )
+                    # 等真表單出現（代表 F5 挑戰已過）
+                    try:
+                        await page.wait_for_selector("#btnQry", state="visible", timeout=15000)
+                    except Exception:
+                        logger.warning("WAF bypass: #btnQry 未顯示，cookies 可能仍無效")
+                    cookies = await ctx.cookies()
+                    self._cookies = {c["name"]: c["value"] for c in cookies}
+                    self._last_warmup_at = time.time()
+                    self._save_to_disk()
+                    elapsed = time.time() - t0
+                    logger.info(
+                        "WAF bypass: warmup OK in %.1fs, got %d cookies",
+                        elapsed, len(self._cookies),
+                    )
+                finally:
+                    await browser.close()
+        except PlaywrightTimeoutError as e:
+            # 將 Playwright 專屬例外收斂成 stdlib asyncio.TimeoutError，
+            # 讓上游 search handler 不必依賴 Playwright 型別。
+            raise asyncio.TimeoutError("WAF warmup 逾時") from e
 
     @staticmethod
     def is_blocked(response_text: str) -> bool:

--- a/mcp_server/updater.py
+++ b/mcp_server/updater.py
@@ -22,6 +22,10 @@ from pathlib import Path
 from urllib.parse import parse_qs, urlparse
 from zoneinfo import ZoneInfo
 
+from mcp_server.ssl_setup import inject_os_trust_store
+
+inject_os_trust_store()
+
 import httpx
 
 logger = logging.getLogger(__name__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,3 +59,7 @@ include = ["mcp_server*"]
 
 [tool.setuptools.package-data]
 mcp_server = ["data/*.json"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["mcp_server/tests"]


### PR DESCRIPTION
Re-opens #2 against current main. #2 was reviewed favourably but the original commits no longer apply after three main refactors since the PR opened (eafc294 Playwright removal → 1feeab0 constitutional court → 2d3807c hybrid WAF bypass).

## Summary

**Kept from #2 (maintainer-praised)**
- Fast-path guard: precise case number search must not run when `keyword` or `main_text` filters are set — otherwise filters are silently ignored and a mis-keyed cache entry is written (`judicial_search.py:102-110`)
- `logger.exception()` replacing `logger.error(\"%s\", e)` — traceback in log
- Input validation: `max_results <= 0`, `offset < 0`
- Integration tests (judicial_search / judicial_doc / regulation / server)
- GitHub Actions CI (Python 3.10 / 3.11 / 3.12)
- SSL bootstrap extracted to `mcp_server/ssl_setup.py`

**Dropped (no longer applicable)**
- Playwright global timeout in search loop — new search path is pure httpx
- `SEARCH_GLOBAL_TIMEOUT` troubleshooting docs — constant removed from `config.py`

**Newly adapted for hybrid WAF architecture**
- `search()` exception dispatch: `(asyncio.TimeoutError, httpx.TimeoutException)` → 逾時 / `httpx.HTTPError` → 連線 / `Exception` → 通用。`httpx.TimeoutException` is an `HTTPError` subclass; ordering matters. `test_search_httpx_timeout_routes_to_timeout_arm` exercises the real httpx timeout path (not just an artificial `asyncio.TimeoutError`)
- `waf_bypass._run_warmup` converts `PlaywrightTimeoutError` → `asyncio.TimeoutError`, so the search layer has no Playwright type dependency

**Maintainer minor addressed**
- `ssl_setup.py` module-body self-call removed; `config.py` / `updater.py` are the real control points

## Test plan

- [x] Local \`pytest mcp_server/tests/\` — 63 passed
- [ ] CI green on 3.10 / 3.11 / 3.12
- [ ] Smoke: \`search_judgments(keyword=\"契約\", max_results=0)\` returns \`max_results 必須大於 0\`
- [ ] Smoke: precise case + main_text 走關鍵字路徑（不靜默忽略主文）

Closes #2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)