### PR TITLE
fix(parsers): explicit UTF-8 encoding for pcode_all.json on Windows

### DIFF
--- a/mcp_server/parsers/judicial_parser.py
+++ b/mcp_server/parsers/judicial_parser.py
@@ -564,7 +564,7 @@ def _load_known_statute_names() -> set[str]:
     pcode_path = Path(__file__).resolve().parent.parent / "data" / "pcode_all.json"
     names = set()
     try:
-        with open(pcode_path, "r") as f:
+        with open(pcode_path, "r", encoding="utf-8") as f:
             data = json.load(f)
         names = set(data["pcode_map"].keys())
     except (FileNotFoundError, KeyError):


### PR DESCRIPTION
## Summary

`_load_known_statute_names()` in `mcp_server/parsers/judicial_parser.py` opens `pcode_all.json` without an explicit `encoding=` argument. On a Windows machine running the zh-TW locale (default codec `cp950` / Big5), Python's open() falls back to cp950, and the JSON contains UTF-8 bytes outside cp950 — so module import dies before any server tool can be reached.

```
UnicodeDecodeError: 'cp950' codec can't decode byte 0x8f in position 145
```

This makes the package unimportable on a fresh Windows + Python install. Every import path that ultimately pulls `mcp_server.tools.judicial_search` (i.e. the server itself, plus most of the integration tests) crashes before `mcp.list_tools()` can return.

## The fix

One line — add `encoding="utf-8"` to match the rest of the codebase:

```python
-    with open(pcode_path, "r") as f:
+    with open(pcode_path, "r", encoding="utf-8") as f:
```

## Why it's a missed instance, not a policy change

Every other JSON load already passes `encoding="utf-8"`:

- `mcp_server/tools/regulations.py:36` — `_load_pcode_all`
- `mcp_server/tools/regulations.py:58` — `_load_law_histories`
- `mcp_server/tools/regulations.py:77` — `reload_pcode_all`
- `mcp_server/updater.py:224` — `should_update_saturday`

`judicial_parser.py:567` was the only outlier.

## Repro

Fresh clone on Windows 11, Python 3.14.3, zh-TW locale:

```powershell
git clone https://github.com/lawchat-oss/mcp-taiwan-legal-db.git
cd mcp-taiwan-legal-db
python -m venv .venv
.venv\Scripts\pip install -e .
.venv\Scripts\python -c "from mcp_server.server import mcp"
# UnicodeDecodeError: 'cp950' codec can't decode byte 0x8f in position 145
```

After the patch the import succeeds and \`asyncio.run(mcp.list_tools())\` returns the expected 8 tools.

## Test plan
- [x] Reproduced the failure on a fresh Windows install (Python 3.14.3, cp950)
- [x] Confirmed import + \`mcp.list_tools()\` returns 8 tools after the patch
- [x] Smoke-tested all 8 tools end-to-end (search_judgments + get_judgment via WAF, query_regulation 民法 §184, get_pcode 民法/勞基法, search_regulations, get_interpretation 釋字第748號, search_interpretations 婚姻, get_citations 釋字第748號)
- [x] No behavior change on non-Windows platforms — `encoding="utf-8"` matches the file's actual encoding everywhere

## Notes

Same bug class as the existing `truststore`-via-`mcp_server.config` SSL bootstrap pattern: silent platform-default behavior diverging from what the code expected. Filing this as a separate small PR rather than bundling.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>