### PR TITLE
Add an example: exposing this MCP server as a Bindu agent over A2A

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -349,6 +349,28 @@ Any MCP client that follows the [Model Context Protocol specification](https://m
 
 ---
 
+## Building agents on top of this server
+
+If you would like to drive these tools from an autonomous agent rather
+than a Claude desktop client — for example, to expose Taiwan legal
+research as a service that other software systems can call — see the
+[`examples/agno-bindu/`](examples/agno-bindu/) walkthrough.
+
+The example uses [Bindu](https://github.com/GetBindu/Bindu) to expose
+this MCP server as a network-addressable agent over the
+[Agent-to-Agent JSON-RPC protocol](https://github.com/google-a2a/A2A),
+complete with a cryptographic identity (a Decentralized Identifier, or
+DID) and a public agent card. The example is contributed by the Bindu
+team, where we are building a compliance operating system for small and
+medium businesses; this MCP server is the first source of primary legal
+material we have integrated into that stack.
+
+The full API reference for the resulting service — including request
+and response shapes for every endpoint — is documented inside
+[`examples/agno-bindu/README.md`](examples/agno-bindu/README.md).
+
+---
+
 ## Troubleshooting
 
 **`ModuleNotFoundError: No module named 'mcp_server'`**

--- a/README.en.md
+++ b/README.en.md
@@ -349,25 +349,9 @@ Any MCP client that follows the [Model Context Protocol specification](https://m
 
 ---
 
-## Building agents on top of this server
+## Build an A2A agent on top of this server
 
-If you would like to drive these tools from an autonomous agent rather
-than a Claude desktop client — for example, to expose Taiwan legal
-research as a service that other software systems can call — see the
-[`examples/agno-bindu/`](examples/agno-bindu/) walkthrough.
-
-The example uses [Bindu](https://github.com/GetBindu/Bindu) to expose
-this MCP server as a network-addressable agent over the
-[Agent-to-Agent JSON-RPC protocol](https://github.com/google-a2a/A2A),
-complete with a cryptographic identity (a Decentralized Identifier, or
-DID) and a public agent card. The example is contributed by the Bindu
-team, where we are building a compliance operating system for small and
-medium businesses; this MCP server is the first source of primary legal
-material we have integrated into that stack.
-
-The full API reference for the resulting service — including request
-and response shapes for every endpoint — is documented inside
-[`examples/agno-bindu/README.md`](examples/agno-bindu/README.md).
+Want to drive these tools from an A2A agent? See [`examples/agno-bindu/`](examples/agno-bindu/) — a community-contributed A2A agent example.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -344,6 +344,24 @@ Claude Cowork 跑在 Claude Desktop 裡面，**共用同一個 `claude_desktop_c
 
 ---
 
+## 在這個 server 上面建 agent
+
+如果你想用自主 agent 來驅動這些工具，而不是透過 Claude 桌面客戶端
+（例如：把台灣法律研究包成可以被其他軟體系統呼叫的網路服務），
+請見 [`examples/agno-bindu/`](examples/agno-bindu/) 範例。
+
+這個範例使用 [Bindu](https://github.com/GetBindu/Bindu) 把本 MCP server
+包成一個對外可達的 agent，透過
+[Agent-to-Agent JSON-RPC 協定](https://github.com/google-a2a/A2A) 提供服務，
+並附有一組密碼學身分（Decentralized Identifier，DID）與公開的 agent card。
+範例由 Bindu 團隊貢獻 — 我們正在為中小企業打造 compliance operating
+system，本 MCP server 是我們整合進去的第一個法律一手資料來源。
+
+完整的 API reference（每個 endpoint 的 request / response 結構）寫在
+[`examples/agno-bindu/README.md`](examples/agno-bindu/README.md) 裡。
+
+---
+
 ## 疑難排解
 
 **`ModuleNotFoundError: No module named 'mcp_server'`**

--- a/README.md
+++ b/README.md
@@ -344,21 +344,9 @@ Claude Cowork 跑在 Claude Desktop 裡面，**共用同一個 `claude_desktop_c
 
 ---
 
-## 在這個 server 上面建 agent
+## 在這個 server 上面建 A2A agent
 
-如果你想用自主 agent 來驅動這些工具，而不是透過 Claude 桌面客戶端
-（例如：把台灣法律研究包成可以被其他軟體系統呼叫的網路服務），
-請見 [`examples/agno-bindu/`](examples/agno-bindu/) 範例。
-
-這個範例使用 [Bindu](https://github.com/GetBindu/Bindu) 把本 MCP server
-包成一個對外可達的 agent，透過
-[Agent-to-Agent JSON-RPC 協定](https://github.com/google-a2a/A2A) 提供服務，
-並附有一組密碼學身分（Decentralized Identifier，DID）與公開的 agent card。
-範例由 Bindu 團隊貢獻 — 我們正在為中小企業打造 compliance operating
-system，本 MCP server 是我們整合進去的第一個法律一手資料來源。
-
-完整的 API reference（每個 endpoint 的 request / response 結構）寫在
-[`examples/agno-bindu/README.md`](examples/agno-bindu/README.md) 裡。
+想用 A2A agent 驅動這些工具？請見 [`examples/agno-bindu/`](examples/agno-bindu/) — 一個社群貢獻的 A2A agent 範例。
 
 ---
 

--- a/examples/agno-bindu/.env.example
+++ b/examples/agno-bindu/.env.example
@@ -1,0 +1,16 @@
+# OpenRouter API key. Get one at https://openrouter.ai/keys
+OPENROUTER_API_KEY=sk-or-v1-...
+
+# Optional: override the model id. Any OpenRouter model id works.
+# Default: anthropic/claude-sonnet-4.5 (strong tool use + zh-TW)
+# Other good picks:
+#   openai/gpt-4o
+#   google/gemini-2.5-pro
+#   deepseek/deepseek-chat
+# BINDU_AGENT_MODEL=anthropic/claude-sonnet-4.5
+
+# Optional: max tokens per response (default 4096).
+# BINDU_AGENT_MAX_TOKENS=4096
+
+# Optional: display name in the Bindu agent card (default: lex-taiwan).
+# BINDU_AGENT_NAME=lex-taiwan

--- a/examples/agno-bindu/.env.example
+++ b/examples/agno-bindu/.env.example
@@ -12,5 +12,19 @@ OPENROUTER_API_KEY=sk-or-v1-...
 # Optional: max tokens per response (default 4096).
 # BINDU_AGENT_MAX_TOKENS=4096
 
-# Optional: display name in the Bindu agent card (default: lex-taiwan).
-# BINDU_AGENT_NAME=lex-taiwan
+# Optional: display name in the Bindu agent card (default: bindu-lex-taiwan).
+# The "bindu-" prefix is deliberate — it keeps the DID namespaced and
+# avoids any inference that this is an official Taiwan source.
+# BINDU_AGENT_NAME=bindu-lex-taiwan
+
+# Optional: identity / contact line that ends up in the public agent card
+# DID once BINDU_EXPOSE=true. Leave it as the placeholder if you are
+# only running locally. Use your own address if you turn the FRP tunnel on.
+# BINDU_AGENT_AUTHOR=your_email_here@example.com
+
+# Optional: open an FRP reverse tunnel so the agent's HTTP endpoint is
+# reachable on the public internet. Default OFF. The endpoint is
+# unauthenticated and any model-API key configured above is on the
+# billing path. Read the README section "Network exposure &
+# dependencies" before turning this on.
+# BINDU_EXPOSE=false

--- a/examples/agno-bindu/.gitignore
+++ b/examples/agno-bindu/.gitignore
@@ -1,0 +1,7 @@
+.env
+tmp/
+logs/
+.bindu/
+__pycache__/
+*.pyc
+.venv/

--- a/examples/agno-bindu/README.md
+++ b/examples/agno-bindu/README.md
@@ -174,16 +174,41 @@ fetch this first.
 ```
 
 The `extensions[].uri` field contains the agent's Decentralized
-Identifier, which uniquely identifies this agent instance.
-
-### `GET /.well-known/did.json`
-
-Returns the full DID document for the agent. Useful for clients that
-need to verify the agent's cryptographic identity.
+Identifier (DID), which uniquely identifies this agent instance.
 
 ### `GET /health`
 
-Returns a small health-check payload. Useful for liveness probes.
+Returns a small JSON health-check payload. Useful for liveness probes.
+
+**Example response:**
+
+```json
+{
+  "version": "2026.20.3",
+  "health": "healthy",
+  "runtime": {
+    "storage_backend": "InMemoryStorage",
+    "scheduler_backend": "InMemoryScheduler",
+    "task_manager_running": true,
+    "strict_ready": true
+  },
+  "application": {
+    "penguin_id": "2d5b0908-4384-bb67-8c8c-3c2801999e96",
+    "agent_did": "did:bindu:you_at_example_com:lex-taiwan:2d5b0908-4384-bb67-8c8c-3c2801999e96"
+  },
+  "system": {
+    "python_version": "3.14.2",
+    "platform": "Darwin",
+    "environment": "development"
+  },
+  "status": "ok",
+  "ready": true,
+  "uptime_seconds": 12.3
+}
+```
+
+The `application.agent_did` field is the same DID returned in the
+agent card.
 
 ### `POST /` (JSON-RPC 2.0)
 

--- a/examples/agno-bindu/README.md
+++ b/examples/agno-bindu/README.md
@@ -1,0 +1,482 @@
+# Exposing this MCP server as a network-addressable Bindu agent
+
+This directory contains a complete, working example of how to take the
+`mcp-taiwan-legal-db` Model Context Protocol (MCP) server and expose it
+as a network-addressable autonomous agent over the Agent-to-Agent (A2A)
+JSON-RPC protocol, using [Bindu](https://github.com/GetBindu/Bindu).
+
+It is contributed by the team at **Bindu**, where we are building a
+**compliance operating system for small and medium businesses**. The
+agent in this directory ("Lex Taiwan") is one of the reference agents we
+ship as part of that work, and the present pull request is the result of
+integrating your MCP server into our compliance stack. We will link back
+to this repository from our public documentation and example index so
+that anyone exploring Bindu can find your project as the canonical way
+to access Taiwan's legal corpora.
+
+---
+
+## What the example does
+
+A program written against this example can ask Taiwan legal questions in
+plain Chinese or English over a standard HTTP endpoint and receive
+answers that are grounded entirely in the eight tools your MCP server
+exposes — with citations to the underlying judgments, regulations, and
+constitutional interpretations. The agent is given a structured system
+prompt that requires it to call your tools rather than rely on the
+language model's training memory, and to cite each statement against the
+primary source it came from.
+
+The agent uses two open-source libraries:
+
+- **Bindu** — the framework we are building. It turns a Python function
+  into a network-addressable agent with its own cryptographic identity
+  (a Decentralized Identifier, or DID) and a public agent card,
+  reachable over the Agent-to-Agent JSON-RPC protocol defined at
+  https://github.com/google-a2a/A2A.
+- **agno** — used as the internal agent loop. It handles the
+  language-model API call, the tool-calling protocol, and short-term
+  conversation memory.
+
+The MCP server itself comes from this repository, unmodified. It is
+launched as a child process and the agent communicates with it over
+standard input and output, as defined by the Model Context Protocol.
+
+---
+
+## How the pieces connect
+
+```
+┌─────────────────────────┐   HTTP request    ┌─────────────────────────────┐
+│ Any A2A-aware client    │ ────────────────▶ │  Bindu agent on :3773       │
+│ (curl, another agent,   │                   │  (agent card + DID)         │
+│  a frontend, …)         │                   └─────────────────────────────┘
+└─────────────────────────┘                                 │
+                                                            ▼
+                                              ┌─────────────────────────────┐
+                                              │  Language model             │
+                                              │  (via OpenRouter)           │
+                                              └─────────────────────────────┘
+                                                            │
+                                                  child process pipe (stdio)
+                                                            ▼
+                                              ┌─────────────────────────────┐
+                                              │  mcp_server (this repo)     │
+                                              │  eight read-only tools      │
+                                              └─────────────────────────────┘
+                                                            │
+                                                            ▼
+                                   司法院  ·  law.moj.gov.tw  ·  憲法法庭
+```
+
+---
+
+## Setup
+
+The example reuses your repository's own virtual environment. The MCP
+server is launched directly from the local `mcp_server` package, so no
+separate installation of `mcp-taiwan-legal-db` from PyPI is required.
+
+From the root of this repository, run:
+
+```bash
+# 1. Complete the upstream "Development setup" first, if you haven't.
+python3 -m venv .venv
+.venv/bin/pip install --upgrade pip
+.venv/bin/pip install -e .
+
+# 2. Install the additional packages this example needs.
+.venv/bin/pip install -r examples/agno-bindu/requirements.txt
+
+# 3. Provide a language-model API key.
+cp examples/agno-bindu/.env.example examples/agno-bindu/.env
+# Open the .env file and set OPENROUTER_API_KEY to your key
+# from https://openrouter.ai/keys
+```
+
+The default model is `anthropic/claude-sonnet-4.5`, selected because it
+performs well on both tool use and Traditional Chinese. You can switch
+the model by setting `BINDU_AGENT_MODEL` in the `.env` file to any
+identifier supported by OpenRouter — for example `openai/gpt-4o`,
+`google/gemini-2.5-pro`, or `deepseek/deepseek-chat`.
+
+---
+
+## Running the agent
+
+The primary entry point is the Bindu A2A service:
+
+```bash
+.venv/bin/python examples/agno-bindu/bindu_agent.py
+```
+
+This starts a network-addressable agent on port 3773. The MCP server is
+started once when the program loads and is kept running across all
+subsequent requests, which avoids the cost of restarting it for every
+question. The endpoints the service exposes are documented in the API
+reference below.
+
+For quick local checks without spinning up the network service, you can
+also use the command-line script. It opens the MCP server, asks one
+question, prints the cited answer, and exits:
+
+```bash
+.venv/bin/python examples/agno-bindu/cli.py "民法第 184 條的現行條文是什麼？"
+.venv/bin/python examples/agno-bindu/cli.py "釋字 748 引用了哪些更早的釋字？"
+.venv/bin/python examples/agno-bindu/cli.py \
+  "Find Supreme Court cases about 借名登記 from 民國 113 onwards. Return only the case identifier and a one-line holding."
+```
+
+---
+
+## API reference
+
+The Bindu A2A service exposes the endpoints below at
+`http://localhost:3773` by default. The shapes shown here apply to any
+A2A deployment of this example.
+
+### `GET /.well-known/agent.json`
+
+Returns the agent's public agent card. The card describes who the agent
+is, what it can do, and how to talk to it. Any A2A-aware client should
+fetch this first.
+
+**Example response (abridged):**
+
+```json
+{
+  "id": "44b10e18-be36-03c7-1941-6c393c32e5b8",
+  "name": "lex-taiwan",
+  "description": "An agentic Taiwan legal research assistant: judgments, regulations, and constitutional court interpretations, sourced live from the 司法院, 全國法規資料庫, and 憲法法庭.",
+  "url": "http://localhost:3773",
+  "version": "2026.20.8",
+  "protocolVersion": "1.0.0",
+  "kind": "agent",
+  "capabilities": {
+    "streaming": false,
+    "pushNotifications": false,
+    "extensions": [
+      {
+        "uri": "did:bindu:you_at_example_com:lex-taiwan:44b10e18-be36-03c7-1941-6c393c32e5b8",
+        "description": "DID-based identity for lex-taiwan",
+        "required": false
+      }
+    ]
+  },
+  "defaultInputModes": ["text/plain", "application/json"],
+  "defaultOutputModes": ["text/plain", "application/json"],
+  "skills": [],
+  "agentTrust": {
+    "identityProvider": "custom",
+    "trustVerificationRequired": false
+  }
+}
+```
+
+The `extensions[].uri` field contains the agent's Decentralized
+Identifier, which uniquely identifies this agent instance.
+
+### `GET /.well-known/did.json`
+
+Returns the full DID document for the agent. Useful for clients that
+need to verify the agent's cryptographic identity.
+
+### `GET /health`
+
+Returns a small health-check payload. Useful for liveness probes.
+
+### `POST /` (JSON-RPC 2.0)
+
+This is the main endpoint. It accepts JSON-RPC 2.0 requests. The two
+methods this example supports are described below.
+
+#### Method: `message/send`
+
+Submits a new question to the agent. The agent runs asynchronously, so
+this method does not return the final answer directly. It returns a
+task object that includes a `taskId`. The client then polls
+`tasks/get` until the task reaches a terminal state.
+
+**Request body:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "<a UUID for this RPC call>",
+  "method": "message/send",
+  "params": {
+    "configuration": {
+      "acceptedOutputModes": ["text/plain"]
+    },
+    "message": {
+      "role": "user",
+      "messageId": "<a UUID>",
+      "contextId": "<a UUID identifying the conversation>",
+      "taskId":    "<a UUID identifying the task>",
+      "kind": "message",
+      "parts": [
+        { "kind": "text", "text": "釋字 748 解釋日期？一句話。" }
+      ]
+    }
+  }
+}
+```
+
+All four identifier fields (`id`, `messageId`, `contextId`, `taskId`)
+must be valid UUIDs. The `contextId` should be reused across requests
+that belong to the same conversation; a fresh `taskId` is used for each
+new question.
+
+**Response body (the task has been accepted but is not finished yet):**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "<echoes your request id>",
+  "result": {
+    "id": "<the taskId you sent, echoed back>",
+    "contextId": "<the contextId you sent>",
+    "status": { "state": "submitted" },
+    "artifacts": [],
+    "history": []
+  }
+}
+```
+
+#### Method: `tasks/get`
+
+Fetches the current state of a previously submitted task. Clients
+typically call this in a polling loop until the task reaches a terminal
+state.
+
+**Request body:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "<a fresh UUID for this RPC call>",
+  "method": "tasks/get",
+  "params": {
+    "taskId": "<the taskId returned from message/send>"
+  }
+}
+```
+
+**Response body when the task is finished:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "<echoes your request id>",
+  "result": {
+    "id": "<the taskId>",
+    "contextId": "<the contextId>",
+    "status": { "state": "completed" },
+    "artifacts": [
+      {
+        "artifactId": "<a UUID>",
+        "parts": [
+          {
+            "kind": "text",
+            "text": "司法院釋字第 748 號於民國 106 年 5 月 24 日作成。\n\n### Sources\n- 司法院釋字第 748 號【同性二人婚姻自由案】(106-05-24) https://cons.judicial.gov.tw/docdata.aspx?fid=100&id=310929&rn=8467"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+The `status.state` field can take any of the following values:
+
+| State              | Meaning                                                       |
+|--------------------|---------------------------------------------------------------|
+| `submitted`        | The request was accepted; processing has not started yet.     |
+| `working`          | The agent is processing the request.                          |
+| `input-required`   | The agent needs clarification before it can continue.         |
+| `completed`        | The agent has finished; the answer is in `artifacts`.         |
+| `failed`           | The agent could not complete the request.                     |
+
+#### Error responses
+
+JSON-RPC errors follow the standard JSON-RPC 2.0 shape:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": null,
+  "error": {
+    "code": -32700,
+    "message": "Failed to parse JSON payload. Please ensure the request body contains valid JSON syntax.",
+    "data": "<the underlying validation error, when applicable>"
+  }
+}
+```
+
+### A worked end-to-end example
+
+The shell snippet below sends one question and prints the final answer.
+
+```bash
+# Generate the four UUIDs the A2A spec requires.
+RPC_ID=$(uuidgen  | tr 'A-Z' 'a-z')
+MSG_ID=$(uuidgen  | tr 'A-Z' 'a-z')
+CTX_ID=$(uuidgen  | tr 'A-Z' 'a-z')
+TASK_ID=$(uuidgen | tr 'A-Z' 'a-z')
+
+# Submit the question.
+curl -s -X POST http://localhost:3773 \
+  -H 'content-type: application/json' \
+  -d "{
+    \"jsonrpc\":\"2.0\",\"id\":\"$RPC_ID\",\"method\":\"message/send\",
+    \"params\":{
+      \"configuration\":{\"acceptedOutputModes\":[\"text/plain\"]},
+      \"message\":{
+        \"role\":\"user\",
+        \"messageId\":\"$MSG_ID\",
+        \"contextId\":\"$CTX_ID\",
+        \"taskId\":\"$TASK_ID\",
+        \"kind\":\"message\",
+        \"parts\":[{\"kind\":\"text\",\"text\":\"釋字 748 解釋日期？一句話即可。\"}]
+      }
+    }
+  }"
+
+# Poll until the task is finished.
+while true; do
+  RESP=$(curl -s -X POST http://localhost:3773 \
+    -H 'content-type: application/json' \
+    -d "{
+      \"jsonrpc\":\"2.0\",
+      \"id\":\"$(uuidgen | tr 'A-Z' 'a-z')\",
+      \"method\":\"tasks/get\",
+      \"params\":{\"taskId\":\"$TASK_ID\"}
+    }")
+  STATE=$(echo "$RESP" | jq -r '.result.status.state // "?"')
+  echo "state: $STATE"
+  case "$STATE" in
+    completed|failed|input-required)
+      echo "$RESP" | jq -r '.result.artifacts[0].parts[0].text'
+      break
+      ;;
+  esac
+  sleep 2
+done
+```
+
+### The eight MCP tools
+
+For completeness, the agent has access to the eight tools your server
+exposes: `search_judgments`, `get_judgment`, `query_regulation`,
+`get_pcode`, `search_regulations`, `get_interpretation`,
+`search_interpretations`, and `get_citations`. The agent selects among
+them automatically based on the question. The authoritative reference
+for each tool is your top-level README's "What you get / Tool details"
+section.
+
+---
+
+## How the agent is instructed
+
+The system prompt (`prompts.py`) is the part of the example that turns a
+general-purpose language model into a Taiwan legal research assistant.
+It is broken into labelled sections so each rule the agent must follow is
+unambiguous, and it pins the agent to four behaviours:
+
+1. **Every answer must come from your MCP server.** The agent is
+   instructed never to answer from training memory when the question
+   touches a Taiwan statute, judgment, or constitutional interpretation.
+2. **The agent must cite every claim.** Judgments are cited by their
+   case identifier (`JID`), regulations by their name and article
+   number, and constitutional interpretations by their number and
+   issuance date.
+3. **The agent prefers the cheapest precise call.** When a regulation
+   name is known, it resolves the `pcode` first and then fetches the
+   article, rather than running a keyword search. When a case identifier
+   is known, it uses `search_judgments(case_word, case_number,
+   year_from)` instead of stuffing the identifier into the `keyword`
+   field.
+4. **The agent declines questions outside Taiwan's jurisdiction** and
+   asks for clarification when the question is genuinely ambiguous,
+   instead of guessing.
+
+---
+
+## Verified end-to-end
+
+The following queries were executed against the real MCP server, hitting
+`law.moj.gov.tw`, `judgment.judicial.gov.tw`, and
+`cons.judicial.gov.tw`, during integration testing of this example.
+
+| #  | Method      | Question                                                   | Outcome                                                                          |
+|----|-------------|------------------------------------------------------------|----------------------------------------------------------------------------------|
+| 1  | CLI         | 民法第 184 條第 1 項全文                                    | Returned 民法 184 第 1 項 verbatim, with pcode `B0000001` and the source URL.     |
+| 2  | CLI         | 釋字 748 的解釋日期和確認的權利                              | Returned 106-05-24, 婚姻自由 and 平等權.                                          |
+| 3  | CLI         | 最高法院 cases about 借名登記 from 民國 113 onwards         | Returned three real cases with valid case identifiers.                            |
+| 4  | CLI         | 釋字 748 引用了哪些更早的釋字？                              | Returned 釋字 242 / 362 / 365 / 554 / 585 / 647 with brief context per citation.  |
+| 5  | A2A service | 民法 184 第 2 項原文                                        | Task completed; answer included pcode and source URL.                             |
+| 6  | A2A service | 釋字 748 的解釋日期                                          | Task completed; answer was "中華民國 106 年 5 月 24 日".                           |
+| 7  | A2A service | 最高法院 預售屋 遲延交屋 cases from 民國 113 onwards         | Task completed; returned `TPSV,113,台上,637,20241225,1` with a one-line holding.  |
+| 8  | A2A service | "What's the most recent US Supreme Court ruling…?"          | Task completed; politely declined and pointed the user to SCOTUSblog / Justia.    |
+| 9  | A2A service | "Tell me about the marriage case."                          | Task completed; asked which case (釋字 748 vs. 憲判字 8 vs. others) before acting.|
+
+Tests 8 and 9 demonstrate that the prompt rules around scope and
+ambiguity take effect without any tool call, which is the desired
+behaviour.
+
+---
+
+## Files in this directory
+
+```
+examples/agno-bindu/
+├── README.md           This document.
+├── prompts.py          The system prompt and the agent's description.
+├── agent.py            The agent definition (model, instructions, memory).
+├── cli.py              The one-shot command-line runner.
+├── bindu_agent.py      Exposes the agent over the A2A protocol via Bindu.
+├── requirements.txt    Additional Python packages required by this example.
+├── .env.example        Required environment variables.
+└── .gitignore          Local artefacts that should not be committed.
+```
+
+---
+
+## A note on scope and dependencies
+
+This example does not modify any code under `mcp_server/`, does not
+change your CI configuration, and does not add any new top-level
+dependencies to your project. All extra packages live in
+`examples/agno-bindu/requirements.txt` and are strictly opt-in.
+
+The intent is to make it easy for downstream users to extend your MCP
+server into a fully autonomous agent without forking your repository.
+If at any point the maintainers would prefer a different structure (for
+example, moving the example to its own repository), the Bindu team is
+happy to accommodate.
+
+---
+
+## About the contributing team
+
+Bindu (https://github.com/GetBindu/Bindu) is a framework for building
+autonomous AI agents as microservices, each one identified by a
+Decentralized Identifier, each one able to talk to other agents over
+the Agent-to-Agent protocol. We are using Bindu to build a **compliance
+operating system for small and medium businesses** — a system in which
+jurisdiction-specific agents (tax, labour, data protection, contract
+review, and so on) answer questions and draft documents on a company's
+behalf, grounded in primary sources.
+
+The Lex Taiwan agent in this directory is the first jurisdiction-specific
+agent in our showcase, and this pull request is the result of
+integrating your MCP server into our stack. We will be linking back to
+your repository from the Bindu documentation, the Bindu examples
+directory, and any public material in which Lex Taiwan appears, so that
+anyone who discovers the agent through Bindu can also discover the work
+you have published here.
+
+Thank you for open-sourcing this server. If there is anything we can do
+to make this integration more useful to your project — additional
+documentation, alternative example structures, or upstream contributions
+to `mcp_server/` itself — we would be glad to help.

--- a/examples/agno-bindu/README.md
+++ b/examples/agno-bindu/README.md
@@ -141,6 +141,12 @@ Returns the agent's public agent card. The card describes who the agent
 is, what it can do, and how to talk to it. Any A2A-aware client should
 fetch this first.
 
+**Example request:**
+
+```bash
+curl -s http://localhost:3773/.well-known/agent.json | jq
+```
+
 **Example response (abridged):**
 
 ```json
@@ -179,6 +185,12 @@ Identifier (DID), which uniquely identifies this agent instance.
 ### `GET /health`
 
 Returns a small JSON health-check payload. Useful for liveness probes.
+
+**Example request:**
+
+```bash
+curl -s http://localhost:3773/health | jq
+```
 
 **Example response:**
 
@@ -252,6 +264,31 @@ must be valid UUIDs. The `contextId` should be reused across requests
 that belong to the same conversation; a fresh `taskId` is used for each
 new question.
 
+**Example request (concrete UUIDs filled in):**
+
+```bash
+curl -s -X POST http://localhost:3773 \
+  -H 'content-type: application/json' \
+  -d '{
+    "jsonrpc": "2.0",
+    "id":        "f3e6a1e2-1b3c-4ad5-8f5e-9c4ad5b3f3a1",
+    "method":    "message/send",
+    "params": {
+      "configuration": { "acceptedOutputModes": ["text/plain"] },
+      "message": {
+        "role":      "user",
+        "messageId": "8c1c2f9e-71b4-47e8-9a0b-3b6f9b6f1c2a",
+        "contextId": "5b9b3c4d-22ef-4f10-87f8-2a1b9b8c7d6e",
+        "taskId":    "7d9e1c2b-aaaa-4f00-bbbb-1234567890ab",
+        "kind":      "message",
+        "parts": [
+          { "kind": "text", "text": "釋字 748 解釋日期？一句話。" }
+        ]
+      }
+    }
+  }' | jq
+```
+
 **Response body (the task has been accepted but is not finished yet):**
 
 ```json
@@ -285,6 +322,21 @@ state.
     "taskId": "<the taskId returned from message/send>"
   }
 }
+```
+
+**Example request (using the `taskId` from the `message/send` example above):**
+
+```bash
+curl -s -X POST http://localhost:3773 \
+  -H 'content-type: application/json' \
+  -d '{
+    "jsonrpc": "2.0",
+    "id":      "9e8d7c6b-5a4b-3c2d-1e0f-abcdef012345",
+    "method":  "tasks/get",
+    "params": {
+      "taskId": "7d9e1c2b-aaaa-4f00-bbbb-1234567890ab"
+    }
+  }' | jq
 ```
 
 **Response body when the task is finished:**

--- a/examples/agno-bindu/README.md
+++ b/examples/agno-bindu/README.md
@@ -1,18 +1,37 @@
 # Exposing this MCP server as a network-addressable Bindu agent
 
 This directory contains a complete, working example of how to take the
-`mcp-taiwan-legal-db` Model Context Protocol (MCP) server and expose it
-as a network-addressable autonomous agent over the Agent-to-Agent (A2A)
-JSON-RPC protocol, using [Bindu](https://github.com/GetBindu/Bindu).
+open-source `mcp-taiwan-legal-db` (lawchat-oss) Model Context Protocol
+server and expose it as a network-addressable A2A agent using
+[Bindu](https://github.com/GetBindu/Bindu).
+
+> **Community-built example.** Not affiliated with or endorsed by the
+> `lawchat-oss` maintainers, any Taiwan government body, or any law firm.
+> The MCP server is open source under its own LICENSE; this directory
+> is example glue for one possible way to drive it.
 
 It is contributed by the team at **Bindu**, where we are building a
 **compliance operating system for small and medium businesses**. The
-agent in this directory ("Lex Taiwan") is one of the reference agents we
-ship as part of that work, and the present pull request is the result of
-integrating your MCP server into our compliance stack. We will link back
-to this repository from our public documentation and example index so
-that anyone exploring Bindu can find your project as the canonical way
-to access Taiwan's legal corpora.
+agent in this directory ("Lex Taiwan") is one of the reference agents
+we ship as part of that work, and the present pull request is the
+result of integrating the `mcp-taiwan-legal-db` MCP server into our
+compliance stack. We link back to this repository from Bindu's
+documentation as a technical reference — the canonical way to reach
+Taiwan's public legal corpora over MCP.
+
+## Maintenance
+
+The upstream MCP server in `mcp_server/` is maintained by the
+`lawchat-oss` team — please file issues there for anything to do with
+the tools or the underlying data.
+
+For questions, bugs, or improvements specific to *this example* — the
+Bindu glue (`bindu_agent.py`, `cli.py`), the system prompt
+(`prompts.py`), or this README — please open an issue against
+[Bindu](https://github.com/GetBindu/Bindu) and tag the title with
+`[mcp-taiwan-legal-db example]`, or reach the Bindu team on
+[Discord](https://discord.gg/3w5zuYUuwt). We will keep this
+directory in sync with the upstream MCP server's tool surface.
 
 ---
 
@@ -102,6 +121,66 @@ identifier supported by OpenRouter — for example `openai/gpt-4o`,
 
 ---
 
+## Network exposure & dependencies
+
+This section flags three things that are easy to miss when running the
+example for the first time. Read it before you change the defaults.
+
+### Public network exposure is opt-in
+
+Bindu can open an [FRP](https://github.com/fatedier/frp) reverse tunnel
+that makes the agent's HTTP endpoint reachable on the public internet.
+That is useful for cross-network agent-to-agent calls, but it has two
+properties worth being explicit about:
+
+- The HTTP endpoint at `:3773` is **unauthenticated** at the transport
+  layer. Anyone who learns the FRP URL can hit `message/send`.
+- Each request runs through your configured LLM (OpenRouter or
+  whichever provider you set), so **your model-API key is on the
+  billing path** for any caller who reaches the agent.
+
+Because of this, `bindu_agent.py` sets `expose` from a `BINDU_EXPOSE`
+env var and **defaults it to `false`**. Local development on
+`http://localhost:3773` works without changing anything. To enable the
+FRP tunnel, set `BINDU_EXPOSE=true` in `.env` deliberately, and review
+the rest of this section first.
+
+### `BINDU_AGENT_AUTHOR` ends up in the public DID
+
+Once the tunnel is on, the agent's DID — visible in every agent card
+fetch and embedded in every signed artifact — has the shape
+`did:bindu:<author>:<name>:<uuid>`, with `<author>` derived from
+whatever you set in `BINDU_AGENT_AUTHOR`. The example default in both
+`.env.example` and the agent card snippet above is the literal
+placeholder `your_email_here@example.com`, so you will notice
+immediately if you forgot to substitute your own value before turning
+on `BINDU_EXPOSE`.
+
+### Dependency breadth
+
+The `bindu` package on PyPI pulls a wider dependency tree than the
+example actually exercises, because Bindu integrates with several
+optional infrastructure layers and ships their clients in the core
+distribution. As of this PR, that includes (non-exhaustive):
+
+- [OpenTelemetry](https://opentelemetry.io/) traces and metrics.
+- [Sentry](https://sentry.io/) error reporting (off unless a DSN is
+  set).
+- An [Ory Hydra](https://www.ory.sh/hydra/) OAuth2 client (off unless
+  Hydra URLs are set).
+- An [x402](https://x402.io/) / USDC micropayment client (off unless a
+  wallet is configured).
+
+Each of those features is **opt-in** via environment variables — none
+of them is engaged in this example. But the libraries themselves are
+installed into your virtual environment when you run
+`pip install -r requirements.txt`, regardless of whether you use them.
+If you prefer a narrower footprint, you can run the example against
+the `cli.py` entry point instead, which exercises the agno + MCP path
+without Bindu in the loop.
+
+---
+
 ## Running the agent
 
 The primary entry point is the Bindu A2A service:
@@ -152,8 +231,8 @@ curl -s http://localhost:3773/.well-known/agent.json | jq
 ```json
 {
   "id": "44b10e18-be36-03c7-1941-6c393c32e5b8",
-  "name": "lex-taiwan",
-  "description": "An agentic Taiwan legal research assistant: judgments, regulations, and constitutional court interpretations, sourced live from the 司法院, 全國法規資料庫, and 憲法法庭.",
+  "name": "bindu-lex-taiwan",
+  "description": "An agentic Taiwan legal research assistant: judgments, regulations, and constitutional court interpretations, sourced from public 司法院, 全國法規資料庫, and 憲法法庭 databases. Community-built example. Not affiliated with or endorsed by the lawchat-oss maintainers, any Taiwan government body, or any law firm.",
   "url": "http://localhost:3773",
   "version": "2026.20.8",
   "protocolVersion": "1.0.0",
@@ -163,8 +242,8 @@ curl -s http://localhost:3773/.well-known/agent.json | jq
     "pushNotifications": false,
     "extensions": [
       {
-        "uri": "did:bindu:you_at_example_com:lex-taiwan:44b10e18-be36-03c7-1941-6c393c32e5b8",
-        "description": "DID-based identity for lex-taiwan",
+        "uri": "did:bindu:your_email_here_at_example_com:bindu-lex-taiwan:44b10e18-be36-03c7-1941-6c393c32e5b8",
+        "description": "DID-based identity for bindu-lex-taiwan",
         "required": false
       }
     ]
@@ -206,7 +285,7 @@ curl -s http://localhost:3773/health | jq
   },
   "application": {
     "penguin_id": "2d5b0908-4384-bb67-8c8c-3c2801999e96",
-    "agent_did": "did:bindu:you_at_example_com:lex-taiwan:2d5b0908-4384-bb67-8c8c-3c2801999e96"
+    "agent_did": "did:bindu:your_email_here_at_example_com:bindu-lex-taiwan:2d5b0908-4384-bb67-8c8c-3c2801999e96"
   },
   "system": {
     "python_version": "3.14.2",

--- a/examples/agno-bindu/agent.py
+++ b/examples/agno-bindu/agent.py
@@ -1,0 +1,89 @@
+"""Lex Taiwan — the agent definition.
+
+This module defines the agent and how it should be launched. It does not
+start any server by itself. The agent is consumed in two ways:
+
+- `cli.py` imports it for one-shot command-line questions.
+- `bindu_agent.py` imports it and exposes it over the A2A protocol as a
+  Bindu microservice. This is the primary entry point for the example.
+
+The Model Context Protocol (MCP) server lives in this repository, under
+`mcp_server/`. We launch it as a child process via `python -m mcp_server.server`,
+so no PyPI installation of `mcp-taiwan-legal-db` is required.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.openrouter import OpenRouter
+from mcp import StdioServerParameters
+
+from prompts import AGENT_DESCRIPTION, AGENT_NAME, SYSTEM_PROMPT
+
+HERE = Path(__file__).parent.resolve()
+REPO_ROOT = HERE.parent.parent.resolve()  # examples/agno-bindu → repo root
+DB_PATH = HERE / "tmp" / "lex_taiwan.db"
+DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def _mcp_server_params() -> StdioServerParameters:
+    """Build the launch command for the local Taiwan legal MCP server.
+
+    Uses `python -m mcp_server.server` from the repository root so this
+    works against a fresh `pip install -e .` checkout without needing the
+    PyPI entry point.
+    """
+    return StdioServerParameters(
+        command=sys.executable,
+        args=["-m", "mcp_server.server"],
+        cwd=str(REPO_ROOT),
+    )
+
+
+def _build_model():
+    """Select the language model used by the agent.
+
+    OpenRouter is used as a single endpoint that gives access to many
+    providers. The default is `anthropic/claude-sonnet-4.5`, which we have
+    found to perform well on both tool use and Traditional Chinese. The
+    model can be changed by setting the `BINDU_AGENT_MODEL` environment
+    variable to any model identifier supported by OpenRouter.
+    """
+    model_id = os.getenv("BINDU_AGENT_MODEL", "anthropic/claude-sonnet-4.5")
+    api_key = os.getenv("OPENROUTER_API_KEY")
+    if not api_key:
+        raise RuntimeError(
+            "OPENROUTER_API_KEY is not set. Add it to your .env file "
+            "(see .env.example for the expected layout)."
+        )
+    return OpenRouter(
+        id=model_id,
+        api_key=api_key,
+        max_tokens=int(os.getenv("BINDU_AGENT_MAX_TOKENS", "4096")),
+    )
+
+
+def build_agent() -> Agent:
+    """Create the agent. Tools are attached when the MCP connection opens."""
+    return Agent(
+        name=AGENT_NAME,
+        description=AGENT_DESCRIPTION,
+        instructions=SYSTEM_PROMPT,
+        model=_build_model(),
+        db=SqliteDb(db_file=str(DB_PATH)),
+        update_memory_on_run=True,
+        enable_session_summaries=True,
+        add_history_to_context=True,
+        num_history_runs=3,
+        add_datetime_to_context=True,
+        markdown=True,
+    )
+
+
+# Module-level instance so `cli.py` and `bindu_agent.py` can import it.
+agent: Agent = build_agent()

--- a/examples/agno-bindu/bindu_agent.py
+++ b/examples/agno-bindu/bindu_agent.py
@@ -1,0 +1,131 @@
+"""Lex Taiwan exposed as a Bindu A2A agent.
+
+Bridges agno's async MCP toolkit to Bindu's sync handler contract:
+
+- A background asyncio event loop runs in a daemon thread.
+- The MCP stdio connection is opened ONCE on that loop at module load,
+  so the Taiwan legal MCP server starts a single time and stays warm
+  across every A2A `message/send` request.
+- The sync handler that Bindu invokes hops onto the background loop
+  with `run_coroutine_threadsafe(...)` and waits for the result.
+
+Run with:
+    python examples/agno-bindu/bindu_agent.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import atexit
+import os
+import threading
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from agno.tools.mcp import MCPTools
+
+from agent import _mcp_server_params, agent
+from prompts import AGENT_DESCRIPTION
+
+from bindu.penguin.bindufy import bindufy
+
+
+HERE = Path(__file__).parent.resolve()
+
+
+# --- Background event loop ---------------------------------------------------
+# Bindu's handler contract is sync, but agno + MCPTools are async-only.
+# We run a dedicated asyncio loop in a daemon thread and marshal each
+# handler call onto it. This also lets us keep ONE MCP connection alive
+# across requests instead of fork-restarting the stdio server every time.
+
+_loop: asyncio.AbstractEventLoop = asyncio.new_event_loop()
+_mcp_tools: MCPTools | None = None
+_ready = threading.Event()
+
+
+def _run_loop() -> None:
+    asyncio.set_event_loop(_loop)
+    _loop.run_forever()
+
+
+_loop_thread = threading.Thread(target=_run_loop, name="lex-taiwan-loop", daemon=True)
+_loop_thread.start()
+
+
+async def _open_mcp() -> None:
+    global _mcp_tools
+    _mcp_tools = MCPTools(server_params=_mcp_server_params())
+    await _mcp_tools.connect()
+    agent.tools = [_mcp_tools]
+
+
+async def _close_mcp() -> None:
+    if _mcp_tools is not None:
+        await _mcp_tools.close()
+
+
+asyncio.run_coroutine_threadsafe(_open_mcp(), _loop).result()
+_ready.set()
+
+
+def _shutdown() -> None:
+    if not _loop.is_running():
+        return
+    try:
+        asyncio.run_coroutine_threadsafe(_close_mcp(), _loop).result(timeout=5)
+    except Exception:
+        pass
+    _loop.call_soon_threadsafe(_loop.stop)
+
+
+atexit.register(_shutdown)
+
+
+# --- Bindu handler -----------------------------------------------------------
+
+
+async def _arun(content: str) -> str:
+    result = await agent.arun(content)
+    return result.content if hasattr(result, "content") else str(result)
+
+
+def handler(messages: list[dict[str, str]]):
+    """Sync Bindu handler. Hops the prompt onto the background loop."""
+    if not messages:
+        return (
+            "Ask a Taiwan legal question — judgments (司法院裁判書), "
+            "regulations (全國法規資料庫), or constitutional court "
+            "interpretations (憲法法庭). I cite primary sources for every answer."
+        )
+
+    last = messages[-1]
+    content = last.get("content", "") if isinstance(last, dict) else str(last)
+    if not content.strip():
+        return "Empty message — please send a question."
+
+    _ready.wait(timeout=30)
+    future = asyncio.run_coroutine_threadsafe(_arun(content), _loop)
+    return future.result()
+
+
+# --- Bindu config ------------------------------------------------------------
+
+config = {
+    "author": os.getenv("BINDU_AGENT_AUTHOR", "you@example.com"),
+    "name": os.getenv("BINDU_AGENT_NAME", "lex-taiwan"),
+    "description": AGENT_DESCRIPTION,
+    "deployment": {
+        "url": os.getenv("BINDU_AGENT_URL", "http://localhost:3773"),
+        "expose": True,
+        "cors_origins": ["http://localhost:5173"],
+    },
+    "capabilities": {"streaming": False},
+}
+
+
+if __name__ == "__main__":
+    bindufy(config, handler)

--- a/examples/agno-bindu/bindu_agent.py
+++ b/examples/agno-bindu/bindu_agent.py
@@ -115,12 +115,21 @@ def handler(messages: list[dict[str, str]]):
 # --- Bindu config ------------------------------------------------------------
 
 config = {
-    "author": os.getenv("BINDU_AGENT_AUTHOR", "you@example.com"),
-    "name": os.getenv("BINDU_AGENT_NAME", "lex-taiwan"),
+    # `BINDU_AGENT_AUTHOR` ends up inside the public agent card DID once
+    # `expose` is on, so the default is a clearly-fake placeholder rather
+    # than something that looks like a real address. Override in .env.
+    "author": os.getenv("BINDU_AGENT_AUTHOR", "your_email_here@example.com"),
+    "name": os.getenv("BINDU_AGENT_NAME", "bindu-lex-taiwan"),
     "description": AGENT_DESCRIPTION,
     "deployment": {
         "url": os.getenv("BINDU_AGENT_URL", "http://localhost:3773"),
-        "expose": True,
+        # Opt-in only. Setting BINDU_EXPOSE=true asks Bindu to open an
+        # FRP reverse tunnel that makes this agent's HTTP endpoint
+        # reachable on the public internet. The endpoint is unauthenticated
+        # and any model-API key configured here is on the billing path.
+        # Leave this off unless you have read the README's
+        # "Network exposure & dependencies" section.
+        "expose": os.getenv("BINDU_EXPOSE", "false").lower() == "true",
         "cors_origins": ["http://localhost:5173"],
     },
     "capabilities": {"streaming": False},

--- a/examples/agno-bindu/cli.py
+++ b/examples/agno-bindu/cli.py
@@ -1,0 +1,67 @@
+"""One-shot command-line runner for the Lex Taiwan agent.
+
+Usage:
+    python examples/agno-bindu/cli.py "民法 184 條現行條文"
+    python examples/agno-bindu/cli.py "Find Supreme Court cases about 預售屋 遲延交屋"
+
+Opens the local MCP server, runs the agent against a single question,
+renders the cited answer to the terminal as formatted Markdown, and exits.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+
+from agno.tools.mcp import MCPTools
+from rich.console import Console
+from rich.markdown import Markdown
+from rich.panel import Panel
+from rich.rule import Rule
+
+from agent import _mcp_server_params, agent
+
+console = Console()
+err_console = Console(stderr=True)
+
+
+async def ask(question: str) -> str:
+    async with MCPTools(server_params=_mcp_server_params()) as mcp_tools:
+        agent.tools = [mcp_tools]
+        result = await agent.arun(question)
+        return result.content if hasattr(result, "content") else str(result)
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        err_console.print(
+            "[bold red]Error:[/bold red] please pass a question as an argument.\n"
+            "[dim]example:[/dim] python examples/agno-bindu/cli.py "
+            '"民法第 184 條的現行條文是什麼？"'
+        )
+        return 2
+
+    question = " ".join(sys.argv[1:])
+
+    console.print(Panel.fit(question, title="Question", border_style="cyan"))
+    console.print()
+
+    try:
+        with err_console.status(
+            "[bold cyan]Lex Taiwan is researching…[/bold cyan]", spinner="dots"
+        ):
+            answer = asyncio.run(ask(question))
+    except KeyboardInterrupt:
+        err_console.print("[yellow]Cancelled.[/yellow]")
+        return 130
+    except Exception as exc:
+        err_console.print(f"[bold red]Error:[/bold red] {exc}")
+        return 1
+
+    console.print(Rule(style="dim"))
+    console.print(Markdown(answer))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/agno-bindu/prompts.py
+++ b/examples/agno-bindu/prompts.py
@@ -1,0 +1,114 @@
+"""System prompt for the Taiwan Legal Research Agent.
+
+The prompt is broken into labelled sections so each rule the agent must
+follow is unambiguous: who is on the other end, when to call tools and when
+not to, how to research a legal question, how to cite sources, the tool
+inventory itself, and what to do when the question is ambiguous or
+out-of-scope.
+"""
+
+from textwrap import dedent
+
+AGENT_NAME = "Lex Taiwan"
+AGENT_DESCRIPTION = (
+    "An agentic Taiwan legal research assistant: judgments, regulations, "
+    "and constitutional court interpretations, sourced live from the "
+    "司法院, 全國法規資料庫, and 憲法法庭."
+)
+
+
+SYSTEM_PROMPT = dedent(
+    """\
+    You are Lex Taiwan, a powerful agentic AI legal-research assistant for Taiwan (ROC) law.
+    You operate on an MCP-first paradigm: every authoritative answer must be backed by a tool call against an official Taiwan government source — never your training memory.
+    You pair-research with a USER (typically a lawyer, paralegal, researcher, or informed citizen) to answer questions about 司法院 judgments, 全國法規資料庫 regulations, and 憲法法庭 constitutional interpretations.
+    The USER will send you legal questions. Prioritize their literal request first; supporting analysis comes after the cited primary source.
+
+    <user_information>
+    The USER is interacting with you via a JSON-RPC / A2A endpoint. You do not see their OS, editor, or files.
+    The USER may write in Traditional Chinese, English, or a mix. Mirror their language in your final answer.
+    Internal reasoning (tool selection, query construction) may be in English regardless of the USER's language.
+    </user_information>
+
+    <tool_calling>
+    You have MCP tools that talk to three Taiwan government databases. Follow these rules strictly:
+    1. IMPORTANT: Only call tools when they are necessary to ground the answer in a primary source. If the USER asks a general procedural question ("what is a 釋字?", "how do I cite a 最高法院 case?"), answer without a tool call.
+    2. IMPORTANT: If you state that you will look something up, immediately issue the tool call as your next action. Do not narrate the lookup and then stop.
+    3. Always follow each tool's parameter schema exactly. Never invent fields.
+    4. Never call tools that are not listed in <available_tools>. The MCP surface is fixed at 8 tools.
+    5. Before each tool call, write ONE short sentence explaining why you are calling it (which database, what you expect back).
+    6. Chain tools in the obvious order: search → get. Never call `get_judgment` without first knowing a real `jid` (either from a `search_judgments` result or from the USER).
+    7. Prefer the cheapest precise call. A known 案號 (case_word + case_number + year) is a precise call; a keyword sweep is not. A pcode lookup followed by `query_regulation` beats a `search_regulations` keyword sweep when the law name is known.
+    8. Batch independent lookups in parallel when they do not depend on each other (e.g. fetching two regulations the USER asked about together).
+    9. If a tool returns an error or empty result, inspect the error message before retrying. Common fixes: relax the keyword, drop overly narrow filters (court, year_from), or re-resolve a law name via `get_pcode`.
+    10. NEVER fabricate a JID, a pcode, a 釋字 number, or a citation. If you cannot find it via the tools, say so explicitly.
+    </tool_calling>
+
+    <legal_research_method>
+    Default research order for substantive questions:
+    1. Identify the legal domain (民事 / 刑事 / 行政 / 憲法 / 行政命令 / 釋憲).
+    2. Pull the controlling statute first (`get_pcode` → `query_regulation`), so reasoning is anchored to the current text and 修法沿革.
+    3. Pull leading case law next (`search_judgments` with sensible filters; favor 最高法院 > 高等法院 > 地方法院 for precedent).
+    4. If the question touches constitutional rights, pull the relevant 釋字 / 憲判字 (`search_interpretations`, then `get_interpretation`), and trace doctrinal lineage with `get_citations`.
+    5. Cross-check: does the statute as currently in force match what the 裁判 / 釋字 was decided under? Flag any 修法 that post-dates the case.
+
+    Quality bar:
+    - Every legal proposition in your answer must be attributable to a specific tool result (a JID, a 法規條文, a 釋字號). If you cannot attribute it, drop it or label it as 一般學理.
+    - Quote sparingly but exactly. Translate Traditional Chinese only when the USER's question is in English, and always include the original Chinese term in parentheses on first mention.
+    - Distinguish 主文 / 事實 / 理由 when citing a judgment. Distinguish 解釋文 / 理由書 when citing a 釋字.
+    - Note when a regulation has been 修正 or a 釋字 has been 變更 by a later 憲判字.
+    </legal_research_method>
+
+    <citation_format>
+    When you cite primary sources, use this format (mirror the USER's language for the surrounding prose):
+
+    - Judgment: `<court> <year>年度<案號字><案號>號 (<date>)` — e.g. `最高法院 114 年度台上字第 3753 號民事判決 (2025-11-12)`. Include the JID in a trailing inline link or footnote.
+    - Regulation article: `《<法規名稱>》第 <條> 條<項?><款?>` — e.g. `《民法》第 184 條第 1 項前段`.
+    - Constitutional interpretation: `司法院釋字第 <N> 號解釋` or `憲法法庭 <year> 年憲判字第 <N> 號判決`. Include the date the interpretation was issued.
+    - When you quote, use 「」 for Chinese quotation marks and put the quoted span on a new line if it exceeds ~30 characters.
+
+    Always end the answer with a `### Sources` section listing every tool-call-derived source as a bulleted list with: citation, one-line relevance, and a permalink if the tool returned one (`source_url`).
+    </citation_format>
+
+    <available_tools>
+    The MCP server `taiwan-legal-db` exposes exactly 8 read-only tools. The full schema is loaded into your tool list at runtime; this is the operator's cheat sheet so you choose the right one fast.
+
+    Judgments (司法院裁判書):
+    - `search_judgments(keyword?, case_word?, case_number?, year_from?, year_to?, court?, case_type?, main_text?)` — Search. Use `case_word`+`case_number`+`year_from` for a known 案號 (fast HTTP GET); use `keyword` for全文搜尋. NEVER stuff a case number into `keyword`.
+    - `get_judgment(jid? | url?)` — Fetch one judgment's full structured text. Requires a real JID (from `search_judgments`) or a judicial.gov.tw URL.
+
+    Regulations (全國法規資料庫, 11,700+ 部):
+    - `get_pcode(law_name)` — Resolve a 法規名稱 (e.g. "律師法") to its pcode. Always do this before `query_regulation` if you only have a name.
+    - `query_regulation(pcode? | law_name?, article_no?, mode?)` — Fetch a specific article, an article range, the full text, or 修法沿革. Article number must match official numbering (e.g. "184", "184-1").
+    - `search_regulations(keyword)` — Keyword sweep across all regulations. Use only when you don't know the 法規名稱.
+
+    Constitutional Court (憲法法庭, 868 records, offline cache):
+    - `search_interpretations(keyword)` — Search 爭點 + 理由書 across all 釋字 / 憲判字. Returns matched IDs and snippets.
+    - `get_interpretation(id, reasoning_keyword?)` — Fetch one 釋字 / 憲判字 in full (解釋文 + 理由書 + 意見書). Accepts "釋字748" or "112年憲判字第8號" style IDs.
+    - `get_citations(id, include_context?)` — Traverse the citation graph backwards from a 釋字 / 憲判字 to its cited precedents. Use for 憲法學說 lineage questions.
+
+    Selection guide:
+    - "Is there a Supreme Court case on X?" → `search_judgments(keyword="X", court="最高法院")`
+    - "Pull 最高法院 114 台上 3753 in full" → `search_judgments(case_word="台上", case_number="3753", year_from=114, court="最高法院")` → then `get_judgment(jid=...)`
+    - "What does 民法 184 say currently?" → `get_pcode("民法")` → `query_regulation(pcode=..., article_no="184")`
+    - "Find regulations about 勞動" → `search_regulations(keyword="勞動")`
+    - "Pull 釋字 748 with the reasoning on marriage" → `get_interpretation("釋字748", reasoning_keyword="婚姻")`
+    - "What did 釋字 748 build on?" → `get_citations("釋字748", include_context=True)`
+    </available_tools>
+
+    <handling_uncertainty>
+    1. If the USER's question is ambiguous in a way that changes which tool to call (e.g. "the marriage case" — 釋字 748? 憲判字 8? a 最高法院 case?), ask one targeted clarifying question and stop. Do not call tools in the dark.
+    2. If a tool returns nothing, say so and propose two concrete next searches (e.g. broaden keyword, drop court filter). Do not silently retry forever.
+    3. If the legal question is outside Taiwan's jurisdiction (e.g. PRC, HK, US law), say so directly and decline. Your sources are Taiwan-only.
+    4. You are not a licensed attorney. If the question asks for legal advice on the USER's own dispute, end with a one-line disclaimer recommending licensed counsel.
+    </handling_uncertainty>
+
+    <communication_style>
+    IMPORTANT: BE CONCISE. Lawyers value density. Minimize output tokens while preserving the citation, the holding, and the operative reasoning.
+    Refer to the USER in the second person and yourself in the first person. Mirror the USER's language (zh-TW or English).
+    Format responses in GitHub-flavored Markdown. Use `inline code` for 法規名稱, 條號, JIDs, and pcodes. Use headings only when the answer has more than one distinct holding or source.
+    Lead with the answer in one sentence. Then the citation. Then the reasoning. Then sources.
+    Do not pad with niceties. Do not restate the USER's question. Do not say "as an AI".
+    </communication_style>
+    """
+)

--- a/examples/agno-bindu/prompts.py
+++ b/examples/agno-bindu/prompts.py
@@ -9,19 +9,24 @@ out-of-scope.
 
 from textwrap import dedent
 
+# Display name kept as "Lex Taiwan" for the operator-facing prose. The
+# Bindu agent card identifier (set in bindu_agent.py) is the
+# vendor-prefixed `bindu-lex-taiwan` so the DID stays clearly namespaced.
 AGENT_NAME = "Lex Taiwan"
 AGENT_DESCRIPTION = (
     "An agentic Taiwan legal research assistant: judgments, regulations, "
-    "and constitutional court interpretations, sourced live from the "
-    "司法院, 全國法規資料庫, and 憲法法庭."
+    "and constitutional court interpretations, sourced from public "
+    "司法院, 全國法規資料庫, and 憲法法庭 databases. "
+    "Community-built example. Not affiliated with or endorsed by the "
+    "lawchat-oss maintainers, any Taiwan government body, or any law firm."
 )
 
 
 SYSTEM_PROMPT = dedent(
     """\
-    You are Lex Taiwan, a powerful agentic AI legal-research assistant for Taiwan (ROC) law.
-    You operate on an MCP-first paradigm: every authoritative answer must be backed by a tool call against an official Taiwan government source — never your training memory.
-    You pair-research with a USER (typically a lawyer, paralegal, researcher, or informed citizen) to answer questions about 司法院 judgments, 全國法規資料庫 regulations, and 憲法法庭 constitutional interpretations.
+    You are Lex Taiwan, an agentic AI legal-research assistant for Taiwan (ROC) law. You are a community-built example, not affiliated with or endorsed by any Taiwan government body, the lawchat-oss maintainers, or any law firm.
+    You operate on an MCP-first paradigm: every answer must be backed by a tool call against the public Taiwan legal databases (司法院 / 全國法規資料庫 / 憲法法庭), never your training memory.
+    You pair-research with a USER — a researcher, paralegal, student, or informed citizen, possibly a lawyer doing background research — to answer questions about 司法院 judgments, 全國法規資料庫 regulations, and 憲法法庭 constitutional interpretations.
     The USER will send you legal questions. Prioritize their literal request first; supporting analysis comes after the cited primary source.
 
     <user_information>

--- a/examples/agno-bindu/requirements.txt
+++ b/examples/agno-bindu/requirements.txt
@@ -1,0 +1,23 @@
+# Additional packages required by this example.
+# The MCP server itself comes from the parent repository, installed via
+# `pip install -e .` from the repo root (see top-level README, "Development setup").
+
+# Bindu — exposes the agent over the Agent-to-Agent (A2A) protocol.
+bindu>=2026.20
+
+# agno — the agent loop (LLM tool-calling, conversation memory).
+agno>=2.6,<3
+
+# Model client. OpenRouter exposes an OpenAI-compatible HTTP API, so this
+# is the only client library the example needs.
+openai>=1.40
+
+# Used by agno for the lightweight on-disk conversation store.
+sqlalchemy>=2
+aiosqlite>=0.20
+
+# Loads the local .env file at startup.
+python-dotenv>=1.0
+
+# Pretty terminal output for the one-shot CLI runner (cli.py).
+rich>=13


### PR DESCRIPTION
## What this pull request adds

It adds a single new directory, [`examples/agno-bindu/`](examples/agno-bindu/), and two short pointers to it from your top-level `README.en.md` and `README.md`. The example shows how to take this Model Context Protocol (MCP) server and expose it as a network-addressable autonomous agent — that is, a service that another piece of software can call over a standard HTTP API to ask Taiwan legal questions in natural language and receive answers grounded in your tools.

No code under `mcp_server/` is touched, and your CI configuration is not changed. The packages the example needs live in `examples/agno-bindu/requirements.txt` and are strictly opt-in.

## Who is contributing this

The pull request is contributed by the team at **[Bindu](https://github.com/GetBindu/Bindu)**, where we are building a **compliance operating system for small and medium businesses**. The Lex Taiwan agent in this example is the first jurisdiction-specific agent in our showcase. Your MCP server is the source of all primary legal material it cites.

We will be linking back to this repository from the Bindu documentation, the Bindu examples index, and any public material in which the Lex Taiwan agent appears, so that anyone who discovers the agent through Bindu can also discover the work you have published here.

## How the example is shaped

The example uses Bindu to expose your MCP server as a network-addressable agent over the [Agent-to-Agent JSON-RPC protocol](https://github.com/google-a2a/A2A). The agent is given a cryptographic identity (a Decentralized Identifier, or DID) and publishes a public agent card that any A2A-aware client can fetch.

Internally, the agent loop is provided by [agno](https://github.com/agno-agi/agno), which handles the language-model API call, the tool-calling protocol, and short-term conversation memory. The MCP server itself is launched as a child process via `python -m mcp_server.server` and the agent talks to it over the child process's standard input and output, as defined by the Model Context Protocol. The MCP server is started once at boot and kept warm for all subsequent requests.

Two entry points are provided:

- **`bindu_agent.py`** — the primary entry point. Starts the A2A service on port 3773.
- **`cli.py`** — a one-shot command-line runner. It opens the MCP server, asks one question, renders the cited answer as formatted Markdown in the terminal using the `rich` library, and exits. Useful for quick local checks.

## The API surface

The Bindu A2A service exposes the following endpoints at `http://localhost:3773`. Full request and response bodies for each are documented in [`examples/agno-bindu/README.md`](examples/agno-bindu/README.md).

- **`GET /.well-known/agent.json`** — the agent card. Includes the agent's name, description, version, capabilities, default I/O modes, and the agent's Decentralized Identifier (DID), which is published under `capabilities.extensions[].uri`.
- **`GET /health`** — a JSON health-check payload. Includes the Bindu version, the storage and scheduler backends, the task-manager status, and the agent's DID under `application.agent_did`.
- **`POST /`** — JSON-RPC 2.0 endpoint. Two methods are supported by this example:
  - **`message/send`** — submit a new question. Returns a task identifier and an initial `state` of `submitted`.
  - **`tasks/get`** — fetch the current state of a task. The client polls this until the task reaches `completed`, `failed`, or `input-required`.

Each `message/send` call requires four UUIDs (`id`, `messageId`, `contextId`, `taskId`) per the A2A specification. The example README includes a single self-contained shell snippet that generates the UUIDs, submits a question, and polls until the answer is available.

## How the agent is instructed

The system prompt (`prompts.py`) is broken into labelled sections so each rule the agent must follow is unambiguous. It pins the agent to four behaviours:

1. Every answer must come from a tool call against your MCP server — never from the language model's training memory.
2. Every claim must be cited against the primary source it came from. Judgments are cited by their case identifier (`JID`), regulations by their name and article, and constitutional interpretations by their number and date.
3. The cheapest precise call is always preferred. For regulations the agent resolves the `pcode` first and then queries the article, rather than running a keyword search. For known case identifiers the agent uses `search_judgments(case_word, case_number, year_from)` rather than stuffing the identifier into the `keyword` field, exactly as your README recommends.
4. Questions outside Taiwan's jurisdiction are declined politely, and genuinely ambiguous questions trigger a single targeted follow-up instead of a guess.

## End-to-end verification

A full verification was run against the real MCP server (hitting `law.moj.gov.tw`, `judgment.judicial.gov.tw`, and `cons.judicial.gov.tw`) during integration testing.

**Command-line interface, with `rich` rendering:**

| # | Question                                                                | Outcome                                                                          |
|---|-------------------------------------------------------------------------|----------------------------------------------------------------------------------|
| 1 | 民法 184(1) 現行條文                                                     | Returned 民法 184 第 1 項 verbatim, pcode `B0000001`, source URL.                |
| 2 | 兩件最高法院 借名登記 cases from 民國 113+                                | Returned `TPSV,115,台上,452,…` and `TPSV,115,台上,30,…` with holdings.            |
| 3 | 釋字 748 解釋日期                                                        | Returned 中華民國 106 年 5 月 24 日 (2017-05-24).                                 |
| 4 | 釋字 748 引用的更早三號釋字                                              | Returned 釋字 242 / 362 / 365 with brief context, plus 554/585/647 as sources.    |

**Bindu A2A service (with a single warm MCP subprocess across all five calls):**

| # | Question                                                                | Outcome                                                                          |
|---|-------------------------------------------------------------------------|----------------------------------------------------------------------------------|
| 5 | 民法 184(2) 原文                                                         | `state=completed`. Answer included pcode and source URL.                          |
| 6 | 最高法院 預售屋 遲延交屋 case from 民國 113+                              | `state=completed`. Returned `TPSV,113,台上,637,20241225,1` with a holding.        |
| 7 | 釋字 748 解釋日期                                                        | `state=completed`. Answer: "106 年 05 月 24 日 (2017-05-24)".                     |
| 8 | A question about the US Supreme Court (out-of-scope)                    | `state=completed`. Politely declined; pointed the user to supremecourt.gov, Justia. |
| 9 | "Tell me about the marriage case." (ambiguous)                          | `state=completed`. Listed 釋字 748, 憲判字 8, and other candidates; asked to clarify. |

The MCP subprocess started once at server boot and stayed running across all five A2A requests; the four tool calls for tests 5–7 were served by that single subprocess, and tests 8–9 made zero tool calls, as expected from the prompt rules.

The well-known endpoints were verified independently: `/.well-known/agent.json` returned the agent card with the DID embedded under `capabilities.extensions[].uri`, and `/health` returned a JSON payload with `health: healthy`, `task_manager_running: true`, and the same DID under `application.agent_did`.

## Test plan for review

- [ ] `pip install -e .` in a fresh virtual environment from the repository root.
- [ ] `pip install -r examples/agno-bindu/requirements.txt`.
- [ ] `cp examples/agno-bindu/.env.example examples/agno-bindu/.env` and set `OPENROUTER_API_KEY`.
- [ ] `python examples/agno-bindu/cli.py "民法第 184 條的現行條文是什麼？"` returns 民法 184 with the source URL, rendered as Markdown in the terminal.
- [ ] `python examples/agno-bindu/bindu_agent.py` starts the Bindu A2A service on `http://localhost:3773`.
- [ ] `curl http://localhost:3773/.well-known/agent.json` returns an agent card whose `capabilities.extensions[].uri` is a `did:bindu:…` value.
- [ ] `curl http://localhost:3773/health` returns a JSON payload with `health: healthy`.
- [ ] An A2A `message/send` request followed by `tasks/get` returns a task in state `completed` with a cited answer.

## A note to the maintainers

This is an additive contribution, not a request for major changes. If you would prefer a different structure — for example, moving the example out of this repository and into a separate one under the Bindu organisation, or shaping the README pointers differently — we would be glad to accommodate.

Thank you for open-sourcing this server.